### PR TITLE
User with `manage_forum` permission can now see all boards and topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [0.1.0-beta.15] - 2021-08-04
+
+### Changed
+
+- User with the `manage_forum` permission can now see all boards and topics, so they can
+  actually manage the forum. With that said, choose wisely who gets this permission!
+
+
 ## [0.1.0-beta.14] - 2021-08-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- User with the `manage_forum` permission can now see all boards and topics, so they can
-  actually manage the forum. With that said, choose wisely who gets this permission!
+- Users with the `manage_forum` permission can now see all boards and topics, so
+  they can actually manage the forum. With that said, choose wisely who gets this
+  permission!
 
 
 ## [0.1.0-beta.14] - 2021-08-02

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ about the available permissions.
 | ID             | Description | Notes|
 |----------------|-------------|------|
 | `basic_access` | Can access the AA-Forum module | Grants access to the forum |
-| `manage_forum` | Can manage the AA-Forum module (Categories, topics and messages) | User with this permission can create, edit and delete boards and categories in the "Administration" view. They can also modify and delete messages and topics in the "Forum" view. **User with this permission are not bound by group restrictions and have access to all boards and topics, so choose wisely who is getting this permission.** |
+| `manage_forum` | Can manage the AA-Forum module (Categories, topics and messages) | Users with this permission can create, edit and delete boards and categories in the "Administration" view. They can also modify and delete messages and topics in the "Forum" view. **Users with this permission are not bound by group restrictions and have access to all boards and topics, so choose wisely who is getting this permission.** |
 
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -372,20 +372,20 @@ about the available permissions.
 
 ## Permissions
 
-| ID                    | Description                   | Notes|
-|-----------------------|-------------------------------|------|
-| `basic_access`        | Can access the AA-Forum module | Grants read access to the forum |
-| `manage_forum`        | Can manage the AA-Forum module (Categories, topics and messages)          | User with this permission can create, edit and delete boards and categories in the "Administration" view. They can also modify and delete messages and topics in the "Forum" view from boards they have access to. They cannot see all boards in the "Forum" view and are still bound by the board's groups restrictions. |
+| ID             | Description | Notes|
+|----------------|-------------|------|
+| `basic_access` | Can access the AA-Forum module | Grants access to the forum |
+| `manage_forum` | Can manage the AA-Forum module (Categories, topics and messages) | User with this permission can create, edit and delete boards and categories in the "Administration" view. They can also modify and delete messages and topics in the "Forum" view. **User with this permission are not bound by group restrictions and have access to all boards and topics, so choose wisely who is getting this permission.** |
 
 
 ## Changelog
 
-See [CHANGELOG.md](CHANGELOG.md)
+See [CHANGELOG.md](https://github.com/ppfeufer/aa-forum/blob/master/CHANGELOG.md)
 
 
 ## Contributing
 
 You want to contribute to this project? That's cool!
 
-Please make sure to read the [contribution guidelines](CONTRIBUTING.md) (I promise,
-it's not much, just some basics)
+Please make sure to read the [contribution guidelines](https://github.com/ppfeufer/aa-forum/blob/master/CONTRIBUTING.md)
+(I promise, it's not much, just some basics)

--- a/aa_forum/__init__.py
+++ b/aa_forum/__init__.py
@@ -4,5 +4,5 @@ A couple of variables to use throughout the app
 
 default_app_config: str = "aa_forum.apps.AaForumConfig"
 
-__version__ = "0.1.0-beta.14"
+__version__ = "0.1.0-beta.15"
 __title__ = "Forum"

--- a/aa_forum/managers.py
+++ b/aa_forum/managers.py
@@ -26,6 +26,11 @@ class BoardQuerySet(models.QuerySet):
         Filter boards that given user has access to.
         """
 
+        # Forum manager have always access, so assign this permission wisely
+        if user.has_perm("aa_forum.manage_forum"):
+            return self
+
+        # If not a forum manager, check if the user has access to the board
         return self.filter(
             Q(groups__in=user.groups.all()) | Q(groups__isnull=True)
         ).distinct()
@@ -48,6 +53,11 @@ class TopicQuerySet(models.QuerySet):
         Filter boards that given user has access to.
         """
 
+        # Forum manager have always access, so assign this permission wisely
+        if user.has_perm("aa_forum.manage_forum"):
+            return self
+
+        # If not a forum manager, check if the user has access to the board
         return self.filter(
             Q(board__groups__in=user.groups.all()) | Q(board__groups__isnull=True)
         ).distinct()
@@ -116,6 +126,11 @@ class MessageQuerySet(models.QuerySet):
         Filter boards that given user has access to.
         """
 
+        # Forum manager have always access, so assign this permission wisely
+        if user.has_perm("aa_forum.manage_forum"):
+            return self
+
+        # If not a forum manager, check if the user has access to the board
         return self.filter(
             Q(topic__board__groups__in=user.groups.all())
             | Q(topic__board__groups__isnull=True)


### PR DESCRIPTION
## Description

### Changed

- Users with the `manage_forum` permission can now see all boards and topics, so they can actually manage the forum. With that said, choose wisely who gets this permission!


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
