### PR TITLE
[FIX] "Copy message link to clipboard" button should always be visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [0.1.0-beta.18] - 2021-08-13
+
+### Fixed
+
+- "Copy message link to clipboard" button should always be visible ...
+
+
 ## [0.1.0-beta.17] - 2021-08-13
 
 ### Added

--- a/aa_forum/__init__.py
+++ b/aa_forum/__init__.py
@@ -4,5 +4,5 @@ A couple of variables to use throughout the app
 
 default_app_config: str = "aa_forum.apps.AaForumConfig"
 
-__version__ = "0.1.0-beta.17"
+__version__ = "0.1.0-beta.18"
 __title__ = "Forum"

--- a/aa_forum/templates/aa_forum/partials/forum/topic/message.html
+++ b/aa_forum/templates/aa_forum/partials/forum/topic/message.html
@@ -33,15 +33,15 @@
                     <div class="col-md-6">
                         {% if not search_term %}
                             <div class="text-right">
-                                {% if message_author == request.user or perms.aa_forum.manage_forum %}
-                                    <button
-                                        class="btn btn-aa-forum-topic-moderation btn-xs btn-aa-forum-copy-to-clipboard"
-                                        title="{% translate 'Copy message link to clipboard' %}"
-                                        data-clipboard-text="{{ request.scheme }}://{{ request.get_host }}{% url 'aa_forum:forum_message' message.topic.board.category.slug message.topic.board.slug message.topic.slug message.pk %}"
-                                    >
-                                        <i class="far fa-copy"></i>
-                                    </button>
+                                <button
+                                    class="btn btn-aa-forum-topic-moderation btn-xs btn-aa-forum-copy-to-clipboard"
+                                    title="{% translate 'Copy message link to clipboard' %}"
+                                    data-clipboard-text="{{ request.scheme }}://{{ request.get_host }}{% url 'aa_forum:forum_message' message.topic.board.category.slug message.topic.board.slug message.topic.slug message.pk %}"
+                                >
+                                    <i class="far fa-copy"></i>
+                                </button>
 
+                                {% if message_author == request.user or perms.aa_forum.manage_forum %}
                                     <a
                                         id="aa-forum-btn-modify-message-{{ message.pk }}"
                                         href="{% url 'aa_forum:forum_message_modify' topic.board.category.slug topic.board.slug topic.slug message.pk %}"


### PR DESCRIPTION
## Description

### Fixed

- "Copy message link to clipboard" button should always be visible ...


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
