### PR TITLE
make admin-models read-only to prevent issue #47 from happening again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [1.0.2] - 2021-09-05
+
+### Fixed
+
+- Admin models are now read-only, to prevent users from creating new entries via the
+  Django admin backend, which will cause issues (see issue #47)
+
+
 ## [1.0.1] - 2021-08-31
 
 ### Changed

--- a/aa_forum/__init__.py
+++ b/aa_forum/__init__.py
@@ -4,5 +4,5 @@ A couple of variables to use throughout the app
 
 default_app_config: str = "aa_forum.apps.AaForumConfig"
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __title__ = "Forum"

--- a/aa_forum/admin.py
+++ b/aa_forum/admin.py
@@ -7,8 +7,51 @@ from django.contrib import admin
 from aa_forum.models import Board, Category, Topic
 
 
+class BaseReadOnlyAdminMixin:
+    """
+    Base "Read Only" mixin for admin models
+    """
+
+    def has_add_permission(self, request):
+        """
+        Has add permissions
+        :param request:
+        :type request:
+        :return:
+        :rtype:
+        """
+
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        """
+        Has change permissions
+        :param request:
+        :type request:
+        :param obj:
+        :type obj:
+        :return:
+        :rtype:
+        """
+
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        """
+        Has delete permissions
+        :param request:
+        :type request:
+        :param obj:
+        :type obj:
+        :return:
+        :rtype:
+        """
+
+        return False
+
+
 @admin.register(Category)
-class CategoryAdmin(admin.ModelAdmin):
+class CategoryAdmin(BaseReadOnlyAdminMixin, admin.ModelAdmin):
     """
     Category admin
     """
@@ -18,7 +61,7 @@ class CategoryAdmin(admin.ModelAdmin):
 
 
 @admin.register(Board)
-class BoardAdmin(admin.ModelAdmin):
+class BoardAdmin(BaseReadOnlyAdminMixin, admin.ModelAdmin):
     """
     Board admin
     """
@@ -28,7 +71,7 @@ class BoardAdmin(admin.ModelAdmin):
 
 
 @admin.register(Topic)
-class TopicAdmin(admin.ModelAdmin):
+class TopicAdmin(BaseReadOnlyAdminMixin, admin.ModelAdmin):
     """
     Topic admin
     """
@@ -36,4 +79,12 @@ class TopicAdmin(admin.ModelAdmin):
     list_display = ("subject", "board", "_messages_count")
 
     def _messages_count(self, obj):
+        """
+        Return the message count per topic
+        :param obj:
+        :type obj:
+        :return:
+        :rtype:
+        """
+
         return obj.messages.count()


### PR DESCRIPTION
## Description

### Fixed

- Admin models are now read-only, to prevent users from creating new entries via the Django admin backend, which will cause issues (see issue #47)

Fixes #47 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
