### PR TITLE
[BACKPORT] [FIX] slugs with unicode characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## [1.0.3] - Unreleased
+## [1.0.3] - 2021-09-10
 
 ### Added
 
 - More details to the admin views
+
+### Fixed
+
+- An issue with unicode characters in category, board or topic names
 
 
 ## [1.0.2] - 2021-09-05

--- a/aa_forum/__init__.py
+++ b/aa_forum/__init__.py
@@ -4,5 +4,5 @@ A couple of variables to use throughout the app
 
 default_app_config: str = "aa_forum.apps.AaForumConfig"
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 __title__ = "Forum"

--- a/aa_forum/admin.py
+++ b/aa_forum/admin.py
@@ -114,7 +114,7 @@ class BoardAdmin(BaseReadOnlyAdminMixin, admin.ModelAdmin):
 
 
 @admin.register(Topic)
-class TopicAdmin(BaseReadOnlyAdminMixin, admin.ModelAdmin):
+class TopicAdmin(admin.ModelAdmin):
     """
     Topic admin
     """

--- a/aa_forum/models.py
+++ b/aa_forum/models.py
@@ -4,6 +4,7 @@ Models
 
 import math
 
+import unidecode
 from ckeditor_uploader.fields import RichTextUploadingField
 
 from django.contrib.auth.models import Group, User
@@ -53,11 +54,11 @@ def _generate_slug(MyModel: models.Model, name: str) -> str:
         name = "hyphen"
 
     run = 0
-    slug_name = slugify(name, allow_unicode=True)
+    slug_name = slugify(unidecode.unidecode(name), allow_unicode=True)
 
     while MyModel.objects.filter(slug=slug_name).exists():
         run += 1
-        slug_name = slugify(f"{name}-{run}", allow_unicode=True)
+        slug_name = slugify(unidecode.unidecode(f"{name}-{run}"), allow_unicode=True)
 
     return slug_name
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ project_install_requirements = [
     "allianceauth>=2.8.2",
     "django-ckeditor",
     "allianceauth-app-utils>=1.8.0",
+    "unidecode",
 ]
 project_python_requires = "~=3.6"
 project_classifiers = [


### PR DESCRIPTION
## Description

### Added

- More details to the admin views

### Fixed

- An issue with unicode characters in category, board or topic names


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
