### PR TITLE
Select the coverage artefact we want to upload

### DIFF
--- a/.github/workflows/automated-checks.yml
+++ b/.github/workflows/automated-checks.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Upload Coverage Artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: coverage
+          name: coverage-python-${{ matrix.python-version }}-django-${{ matrix.django-version }}
           path: coverage.xml
           if-no-files-found: ignore
 
@@ -131,7 +131,7 @@ jobs:
         uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-          files: artifacts/coverage/coverage.xml # optional
+          files: artifacts/coverage-python-3.9-django-3.2/coverage.xml # optional
 #          flags: unittests # optional
 #          name: codecov-umbrella # optional
 #          fail_ci_if_error: true # optional (default = false)
@@ -141,7 +141,7 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@v1
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: artifacts/coverage/coverage.xml
+          coverage-reports: artifacts/coverage-python-3.9-django-3.2/coverage.xml
 
   # Pypi Build Test
   pypi-build-test:


### PR DESCRIPTION
This way we keep consistent with which artefact we upload and not throw just some random one up there ...

## Description

Select the coverage artefact we want to upload

This way we keep consistent with which artefact we upload and not throw just some random one up there ...


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked my code and corrected any misspellings
