### PR TITLE
Fix delete last child topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [In development] - Unreleased
 
+### Fixed
+
+- Deleting last topic of a child board results in NoReverseMatch error on index page
 
 ## [1.4.1] - 2022-01-19
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ graph_models:
 
 coverage:
 	rm -rfv htmlcov && \
-	coverage run ../myauth/manage.py test $(package) --keepdb --failfast && coverage html && coverage report
+	coverage run ../myauth/manage.py test $(package) --keepdb --failfast && coverage html && coverage report -m
 
 build_test:
 	rm -rfv dist && \

--- a/aa_forum/models.py
+++ b/aa_forum/models.py
@@ -166,6 +166,7 @@ class Board(models.Model):
         related_name="+",
         on_delete=models.SET_DEFAULT,
         help_text="Shortcut for better performance",
+        # for adding "Re:" if needed, must be within the same topic as last message
     )
     last_message = models.ForeignKey(
         "Message",

--- a/aa_forum/models.py
+++ b/aa_forum/models.py
@@ -221,13 +221,6 @@ class Board(models.Model):
         Update the first and last message for this board - and parent board if needed.
         """
 
-        self.first_message = (
-            Message.objects.filter(
-                Q(topic__board=self) | Q(topic__board__parent_board=self)
-            )
-            .order_by("time_posted")
-            .first()
-        )
         self.last_message = (
             Message.objects.filter(
                 Q(topic__board=self) | Q(topic__board__parent_board=self)
@@ -235,6 +228,12 @@ class Board(models.Model):
             .order_by("-time_posted")
             .first()
         )
+        if self.last_message:
+            self.first_message = self.last_message.topic.messages.order_by(
+                "time_posted"
+            ).first()
+        else:
+            self.first_message = None
         self.save(update_fields=["first_message", "last_message"])
         if self.parent_board:
             self.parent_board._update_message_references()

--- a/aa_forum/models.py
+++ b/aa_forum/models.py
@@ -216,7 +216,7 @@ class Board(models.Model):
 
         return reverse("aa_forum:forum_board", args=[self.category.slug, self.slug])
 
-    def update_last_message(self):
+    def _update_last_message(self):
         """
         Update the last message for this board.
         """
@@ -327,7 +327,7 @@ class Topic(models.Model):
         super().delete(*args, **kwargs)
 
         if board_needs_update:
-            self.board.update_last_message()
+            self.board._update_last_message()
 
     def get_absolute_url(self) -> str:
         """
@@ -339,7 +339,7 @@ class Topic(models.Model):
             args=[self.board.category.slug, self.board.slug, self.slug],
         )
 
-    def update_last_message(self):
+    def _update_last_message(self):
         """
         Update the last message for this topic.
         """
@@ -457,10 +457,10 @@ class Message(models.Model):
         super().delete(*args, **kwargs)
 
         if topic_needs_update:
-            self.topic.update_last_message()
+            self.topic._update_last_message()
 
         if board_needs_update:
-            self.topic.board.update_last_message()
+            self.topic.board._update_last_message()
 
     def get_absolute_url(self):
         """

--- a/aa_forum/scripts/fake_messages.py
+++ b/aa_forum/scripts/fake_messages.py
@@ -89,11 +89,11 @@ def run():
                             user_created_id=random.choice(user_ids),
                         )
 
-                    topic.update_last_message()
+                    topic._update_last_message()
 
             print(f"Updating {len(boards)} boards...")
 
             for board in boards:
-                board.update_last_message()
+                board._update_last_message()
 
     print("DONE")

--- a/aa_forum/scripts/fake_messages.py
+++ b/aa_forum/scripts/fake_messages.py
@@ -89,11 +89,11 @@ def run():
                             user_created_id=random.choice(user_ids),
                         )
 
-                    topic._update_last_message()
+                    topic._update_message_references()
 
             print(f"Updating {len(boards)} boards...")
 
             for board in boards:
-                board._update_last_message()
+                board._update_message_references()
 
     print("DONE")

--- a/aa_forum/tests/factories.py
+++ b/aa_forum/tests/factories.py
@@ -1,7 +1,0 @@
-from ..models import Message
-
-
-def create_message(**kwargs):
-    if "message" not in kwargs:
-        kwargs["message"] = "dummy text"
-    return Message.objects.create(**kwargs)

--- a/aa_forum/tests/factories.py
+++ b/aa_forum/tests/factories.py
@@ -1,0 +1,7 @@
+from ..models import Message
+
+
+def create_message(**kwargs):
+    if "message" not in kwargs:
+        kwargs["message"] = "dummy text"
+    return Message.objects.create(**kwargs)

--- a/aa_forum/tests/test_models.py
+++ b/aa_forum/tests/test_models.py
@@ -13,8 +13,16 @@ from django.urls import reverse
 from django.utils.timezone import now
 
 # AA Forum
-from aa_forum.models import Board, Category, Message, Topic
-from aa_forum.tests.utils import create_fake_messages, create_fake_user, my_get_setting
+from aa_forum.models import Board
+from aa_forum.tests.utils import (
+    create_board,
+    create_category,
+    create_fake_messages,
+    create_fake_user,
+    create_message,
+    create_topic,
+    my_get_setting,
+)
 
 MODELS_PATH = "aa_forum.models"
 
@@ -28,22 +36,20 @@ class TestBoard(TestCase):
         cls.group = Group.objects.create(name="Superhero")
 
     def setUp(self) -> None:
-        self.category = Category.objects.create(name="Science")
+        self.category = create_category(name="Science")
 
     def test_model_string_names(self):
-        board = Board.objects.create(name="Physics", category=self.category)
+        board = create_board(name="Physics", category=self.category)
 
         self.assertEqual(str(board), "Physics")
 
     def test_should_update_last_message_when_message_created(self):
         # given
-        board = Board.objects.create(name="Physics", category=self.category)
-        topic = Topic.objects.create(subject="Mysteries", board=board)
+        board = create_board(category=self.category)
+        topic = create_topic(board=board)
 
         # when
-        message = Message.objects.create(
-            topic=topic, user_created=self.user, message="What is dark energy?"
-        )
+        message = create_message(topic=topic, user_created=self.user)
 
         # then
         board.refresh_from_db()
@@ -51,22 +57,14 @@ class TestBoard(TestCase):
 
     def test_should_update_last_message_when_message_created_in_child_board(self):
         # given
-        board = Board.objects.create(name="Physics", category=self.category)
-        child_board = Board.objects.create(
-            name="Thermodynamics", category=self.category, parent_board=board
-        )
-        topic_board = Topic.objects.create(subject="Mysteries", board=board)
-        topic_child_board = Topic.objects.create(
-            subject="Solved Mysteries", board=child_board
-        )
-        Message.objects.create(
-            topic=topic_board, user_created=self.user, message="What is dark energy?"
-        )
+        board = create_board(category=self.category)
+        child_board = create_board(category=self.category, parent_board=board)
+        topic_board = create_topic(board=board)
+        topic_child_board = create_topic(board=child_board)
+        create_message(topic=topic_board, user_created=self.user)
         # when
-        message_child_board = Message.objects.create(
-            topic=topic_child_board,
-            user_created=self.user,
-            message="What is heat?",
+        message_child_board = create_message(
+            topic=topic_child_board, user_created=self.user
         )
 
         # then
@@ -75,9 +73,9 @@ class TestBoard(TestCase):
 
     # def test_should_update_last_message_when_message_is_deleted(self):
     #     # given
-    #     board = Board.objects.create(name="Physics", category=self.category)
-    #     topic = Topic.objects.create(subject="Mysteries", board=board)
-    #     message = Message.objects.create(
+    #     board = create_board(name="Physics", category=self.category)
+    #     topic = create_topic(subject="Mysteries", board=board)
+    #     message = create_message(
     #         topic=topic, user_created=self.user, message="What is dark energy?"
     #     )
     #     # when
@@ -89,7 +87,7 @@ class TestBoard(TestCase):
 
     def test_should_return_url(self):
         # given
-        board = Board.objects.create(name="Physics", category=self.category)
+        board = create_board(category=self.category, name="Physics")
 
         # when
         url = board.get_absolute_url()
@@ -102,7 +100,7 @@ class TestBoard(TestCase):
 
     def test_should_return_board_with_no_groups(self):
         # given
-        board = Board.objects.create(name="Physics", category=self.category)
+        board = create_board(category=self.category)
 
         # when
         result = Board.objects.user_has_access(self.user).get(pk=board.pk)
@@ -112,7 +110,7 @@ class TestBoard(TestCase):
 
     def test_should_return_board_for_group_member(self):
         # given
-        board = Board.objects.create(name="Physics", category=self.category)
+        board = create_board(category=self.category)
         board.groups.add(self.group)
 
         self.user.groups.add(self.group)
@@ -125,24 +123,22 @@ class TestBoard(TestCase):
 
     def test_should_return_child_board_for_group_member(self):
         # given
-        board = Board.objects.create(name="Physics", category=self.category)
+        board = create_board(category=self.category)
         board.groups.add(self.group)
 
         self.user.groups.add(self.group)
 
-        board_2 = Board.objects.create(
-            name="Thermal Theories", category=self.category, parent_board=board
-        )
+        child_board = create_board(category=self.category, parent_board=board)
 
         # when
-        result = Board.objects.user_has_access(self.user).get(pk=board_2.pk)
+        result = Board.objects.user_has_access(self.user).get(pk=child_board.pk)
 
         # then
         self.assertTrue(result)
 
     def test_should_not_return_board_for_non_group_member(self):
         # given
-        board = Board.objects.create(name="Physics", category=self.category)
+        board = create_board(category=self.category)
         board.groups.add(self.group)
 
         with self.assertRaises(Board.DoesNotExist):
@@ -150,30 +146,28 @@ class TestBoard(TestCase):
 
     def test_should_not_return_child_board_for_non_group_member(self):
         # given
-        board = Board.objects.create(name="Physics", category=self.category)
+        board = create_board(category=self.category)
         board.groups.add(self.group)
-        board_2 = Board.objects.create(
-            name="Thermal Theories", category=self.category, parent_board=board
-        )
+        board_2 = create_board(category=self.category, parent_board=board)
 
         with self.assertRaises(Board.DoesNotExist):
             Board.objects.user_has_access(self.user).get(pk=board_2.pk)
 
     def test_should_generate_new_slug_when_slug_already_exists(self):
         # given
-        board = Board.objects.create(name="Physics", category=self.category)
+        board = create_board(category=self.category)
         board.slug = "dummy"  # we are faking the same slug here
         board.save()
 
         # when
-        board = Board.objects.create(name="Dummy", category=self.category)
+        board = create_board(name="Dummy", category=self.category)
 
         # then
         self.assertEqual(board.slug, "dummy-1")
 
     def test_should_not_allow_creation_with_hyphen_slugs(self):
         # when
-        board = Board.objects.create(name="Dummy", category=self.category, slug="-")
+        board = create_board(name="Dummy", category=self.category, slug="-")
 
         # then
         self.assertEqual(board.slug, "dummy")
@@ -187,19 +181,19 @@ class TestCategory(TestCase):
         cls.user = create_fake_user(1001, "Bruce Wayne")
 
     def test_model_string_names(self):
-        category = Category.objects.create(name="Science")
+        category = create_category(name="Science")
 
         self.assertEqual(str(category), "Science")
 
     def test_should_create_new_category_with_slug(self):
         # when
-        category = Category.objects.create(name="Science")
+        category = create_category(name="Science")
 
         # then
         self.assertEqual(category.slug, "science")
 
     def test_should_keep_existing_slug_when_changing_name(self):
-        category = Category.objects.create(name="Science")
+        category = create_category(name="Science")
 
         # when
         category.name = "Politics"
@@ -211,26 +205,26 @@ class TestCategory(TestCase):
 
     def test_should_generate_new_slug_when_slug_already_exists(self):
         # given
-        category = Category.objects.create(name="Science")
+        category = create_category(name="Science")
         category.slug = "dummy"  # we are faking the same slug here
         category.save()
 
         # when
-        category = Category.objects.create(name="Dummy")
+        category = create_category(name="Dummy")
 
         # then
         self.assertEqual(category.slug, "dummy-1")
 
     def test_should_not_allow_creation_with_hyphen_slugs(self):
         # when
-        category = Category.objects.create(name="Science", slug="-")
+        category = create_category(name="Science", slug="-")
 
         # then
         self.assertEqual(category.slug, "science")
 
     def test_should_not_allow_to_update_slug_to_hyphen(self):
         # given
-        category = Category.objects.create(name="Science")
+        category = create_category(name="Science")
 
         # when
         category.slug = "-"
@@ -250,29 +244,23 @@ class TestMessage(TestCase):
         cls.user = create_fake_user(1001, "Bruce Wayne")
 
     def setUp(self) -> None:
-        category = Category.objects.create(name="Science")
+        category = create_category()
 
-        self.board = Board.objects.create(name="Physics", category=category)
-        self.child_board = Board.objects.create(
-            name="Astropyhsics", category=category, parent_board=self.board
-        )
-        self.topic = Topic.objects.create(subject="Mysteries", board=self.board)
-        self.child_topic = Topic.objects.create(
-            subject="Black Holes", board=self.child_board
-        )
+        self.board = create_board(category=category)
+        self.child_board = create_board(category=category, parent_board=self.board)
+        self.topic = create_topic(board=self.board)
+        self.child_topic = create_topic(board=self.child_board)
 
     def test_model_string_names(self):
-        message = Message.objects.create(
-            topic=self.topic, user_created=self.user, message="What is dark energy?"
-        )
+        # when
+        message = create_message(topic=self.topic, user_created=self.user)
 
+        # then
         self.assertEqual(str(message), str(message.pk))
 
     def test_should_update_first_and_last_messages_when_saving_1(self):
         # when
-        message = Message.objects.create(
-            topic=self.topic, user_created=self.user, message="What is dark matter?"
-        )
+        message = create_message(topic=self.topic, user_created=self.user)
 
         # then
         self.topic.refresh_from_db()
@@ -284,14 +272,10 @@ class TestMessage(TestCase):
 
     def test_should_update_first_and_last_messages_when_saving_2(self):
         # given
-        message_1 = Message.objects.create(
-            topic=self.topic, user_created=self.user, message="What is dark matter?"
-        )
+        message_1 = create_message(topic=self.topic, user_created=self.user)
 
         # when
-        message_2 = Message.objects.create(
-            topic=self.topic, user_created=self.user, message="What is dark energy?"
-        )
+        message_2 = create_message(topic=self.topic, user_created=self.user)
 
         # then
         self.topic.refresh_from_db()
@@ -303,9 +287,7 @@ class TestMessage(TestCase):
 
     def test_should_update_first_and_last_messages_when_saving_3(self):
         # when
-        message = Message.objects.create(
-            topic=self.child_topic, user_created=self.user, message="text"
-        )
+        message = create_message(topic=self.child_topic, user_created=self.user)
 
         # then
         self.child_topic.refresh_from_db()
@@ -319,33 +301,53 @@ class TestMessage(TestCase):
         self.assertEqual(self.board.first_message, message)
 
     def test_should_update_first_and_last_messages_when_saving_4(self):
-        message = Message.objects.create(
-            topic=self.topic, user_created=self.user, message="What is dark matter?"
-        )
+        # given
+        message = create_message(topic=self.topic, user_created=self.user)
+
         # when
-        child_message = Message.objects.create(
-            topic=self.child_topic, user_created=self.user, message="text"
-        )
+        child_message = create_message(topic=self.child_topic, user_created=self.user)
 
         # then
         self.child_topic.refresh_from_db()
         self.child_board.refresh_from_db()
+        self.topic.refresh_from_db()
         self.board.refresh_from_db()
         self.assertEqual(self.child_topic.last_message, child_message)
         self.assertEqual(self.child_topic.first_message, child_message)
         self.assertEqual(self.child_board.last_message, child_message)
         self.assertEqual(self.child_board.first_message, child_message)
+        self.assertEqual(self.topic.last_message, message)
+        self.assertEqual(self.topic.last_message, message)
         self.assertEqual(self.board.last_message, child_message)
-        self.assertEqual(self.board.first_message, message)
+        self.assertEqual(self.board.first_message, child_message)
+
+    def test_should_update_first_and_last_messages_when_saving_5(self):
+        # given
+        message_1 = create_message(topic=self.topic, user_created=self.user)
+        message_2 = create_message(topic=self.topic, user_created=self.user)
+
+        # when
+        child_message_1 = create_message(topic=self.child_topic, user_created=self.user)
+        child_message_2 = create_message(topic=self.child_topic, user_created=self.user)
+
+        # then
+        self.child_topic.refresh_from_db()
+        self.child_board.refresh_from_db()
+        self.topic.refresh_from_db()
+        self.board.refresh_from_db()
+        self.assertEqual(self.child_topic.first_message, child_message_1)
+        self.assertEqual(self.child_topic.last_message, child_message_2)
+        self.assertEqual(self.child_board.first_message, child_message_1)
+        self.assertEqual(self.child_board.last_message, child_message_2)
+        self.assertEqual(self.topic.first_message, message_1)
+        self.assertEqual(self.topic.last_message, message_2)
+        self.assertEqual(self.board.first_message, child_message_1)
+        self.assertEqual(self.board.last_message, child_message_2)
 
     def test_should_update_message_references_when_deleting_last_message_1(self):
         # given
-        message_1 = Message.objects.create(
-            topic=self.topic, user_created=self.user, message="What is dark matter?"
-        )
-        message_2 = Message.objects.create(
-            topic=self.topic, user_created=self.user, message="What is dark energy?"
-        )
+        message_1 = create_message(topic=self.topic, user_created=self.user)
+        message_2 = create_message(topic=self.topic, user_created=self.user)
 
         # when
         message_2.delete()
@@ -360,12 +362,8 @@ class TestMessage(TestCase):
 
     def test_should_update_message_references_when_deleting_last_message_2(self):
         # given
-        message_1 = Message.objects.create(
-            topic=self.topic, user_created=self.user, message="What is dark matter?"
-        )
-        message_2 = Message.objects.create(
-            topic=self.topic, user_created=self.user, message="What is dark energy?"
-        )
+        message_1 = create_message(topic=self.topic, user_created=self.user)
+        message_2 = create_message(topic=self.topic, user_created=self.user)
 
         # when
         message_1.delete()
@@ -380,14 +378,8 @@ class TestMessage(TestCase):
 
     def test_should_update_message_references_when_deleting_last_message_3(self):
         # given
-        message = Message.objects.create(
-            topic=self.topic, user_created=self.user, message="What is dark matter?"
-        )
-        child_message = Message.objects.create(
-            topic=self.child_topic,
-            user_created=self.user,
-            message="What is dark energy?",
-        )
+        message = create_message(topic=self.topic, user_created=self.user)
+        child_message = create_message(topic=self.child_topic, user_created=self.user)
 
         # when
         child_message.delete()
@@ -405,14 +397,8 @@ class TestMessage(TestCase):
 
     def test_should_update_message_references_when_deleting_last_message_4(self):
         # given
-        message = Message.objects.create(
-            topic=self.topic, user_created=self.user, message="What is dark matter?"
-        )
-        child_message = Message.objects.create(
-            topic=self.child_topic,
-            user_created=self.user,
-            message="What is dark energy?",
-        )
+        message = create_message(topic=self.topic, user_created=self.user)
+        child_message = create_message(topic=self.child_topic, user_created=self.user)
 
         # when
         message.delete()
@@ -430,9 +416,7 @@ class TestMessage(TestCase):
 
     def test_should_reset_message_references_when_deleting_last_message_1(self):
         # given
-        message = Message.objects.create(
-            topic=self.topic, user_created=self.user, message="What is dark matter?"
-        )
+        message = create_message(topic=self.topic, user_created=self.user)
 
         # when
         message.delete()
@@ -447,9 +431,7 @@ class TestMessage(TestCase):
 
     def test_should_return_url_first_page(self):
         # given
-        message = Message.objects.create(
-            topic=self.topic, user_created=self.user, message="What is dark energy?"
-        )
+        message = create_message(topic=self.topic, user_created=self.user)
         url = message.get_absolute_url()
 
         # then
@@ -496,26 +478,22 @@ class TestTopic(TestCase):
         cls.user = create_fake_user(1001, "Bruce Wayne")
 
     def setUp(self) -> None:
-        category = Category.objects.create(name="Science")
+        category = create_category(name="Science")
 
-        self.board = Board.objects.create(name="Physics", category=category)
-        self.child_board = Board.objects.create(
-            name="Chemistry", category=category, parent_board=self.board
-        )
+        self.board = create_board(category=category, name="Physics")
+        self.child_board = create_board(category=category, parent_board=self.board)
 
     def test_model_string_names(self):
-        topic = Topic.objects.create(subject="Mysteries", board=self.board)
+        topic = create_topic(subject="Mysteries", board=self.board)
 
         self.assertEqual(str(topic), "Mysteries")
 
     def test_should_update_last_message_when_message_is_created(self):
         # given
-        topic = Topic.objects.create(subject="Mysteries", board=self.board)
+        topic = create_topic(subject="Mysteries", board=self.board)
 
         # when
-        message = Message.objects.create(
-            topic=topic, user_created=self.user, message="What is dark energy?"
-        )
+        message = create_message(topic=topic, user_created=self.user)
 
         # then
         topic.refresh_from_db()
@@ -523,12 +501,10 @@ class TestTopic(TestCase):
 
     def test_should_update_last_message_when_message_is_created_child_board(self):
         # given
-        child_topic = Topic.objects.create(subject="Mysteries", board=self.child_board)
+        child_topic = create_topic(board=self.child_board)
 
         # when
-        child_message = Message.objects.create(
-            topic=child_topic, user_created=self.user, message="What is dark energy?"
-        )
+        child_message = create_message(topic=child_topic, user_created=self.user)
 
         # then
         child_topic.refresh_from_db()
@@ -536,18 +512,14 @@ class TestTopic(TestCase):
 
     def test_should_update_last_message_after_topic_deletion(self):
         # given
-        topic_1 = Topic.objects.create(subject="Mysteries", board=self.board)
-        topic_2 = Topic.objects.create(subject="Recent Discoveries", board=self.board)
+        topic_1 = create_topic(board=self.board)
+        topic_2 = create_topic(board=self.board)
         my_now = now() - dt.timedelta(hours=1)
 
         with patch("django.utils.timezone.now", lambda: my_now):
-            message_1 = Message.objects.create(
-                topic=topic_1, user_created=self.user, message="What is dark matter?"
-            )
+            message_1 = create_message(topic=topic_1, user_created=self.user)
 
-        message_2 = Message.objects.create(
-            topic=topic_2, user_created=self.user, message="Energy of the Higgs boson"
-        )
+        message_2 = create_message(topic=topic_2, user_created=self.user)
 
         self.board.refresh_from_db()
         self.assertEqual(self.board.last_message, message_2)
@@ -561,18 +533,14 @@ class TestTopic(TestCase):
 
     def test_should_not_update_last_message_after_topic_deletion(self):
         # given
-        topic_1 = Topic.objects.create(subject="Mysteries", board=self.board)
-        topic_2 = Topic.objects.create(subject="Recent Discoveries", board=self.board)
+        topic_1 = create_topic(board=self.board)
+        topic_2 = create_topic(board=self.board)
         my_now = now() - dt.timedelta(hours=1)
 
         with patch("django.utils.timezone.now", lambda: my_now):
-            Message.objects.create(
-                topic=topic_1, user_created=self.user, message="What is dark matter?"
-            )
+            create_message(topic=topic_1, user_created=self.user)
 
-        message_2 = Message.objects.create(
-            topic=topic_2, user_created=self.user, message="Energy of the Higgs boson"
-        )
+        message_2 = create_message(topic=topic_2, user_created=self.user)
 
         self.board.refresh_from_db()
         self.assertEqual(self.board.last_message, message_2)
@@ -586,7 +554,7 @@ class TestTopic(TestCase):
 
     def test_should_return_url(self):
         # given
-        topic = Topic.objects.create(subject="Mysteries", board=self.board)
+        topic = create_topic(subject="Mysteries", board=self.board)
 
         # when
         url = topic.get_absolute_url()
@@ -599,19 +567,19 @@ class TestTopic(TestCase):
 
     def test_should_generate_new_slug_when_slug_already_exists(self):
         # given
-        topic = Topic.objects.create(subject="Mysteries", board=self.board)
+        topic = create_topic(board=self.board)
         topic.slug = "dummy"  # we are faking the same slug here
         topic.save()
 
         # when
-        topic = Topic.objects.create(subject="Dummy", board=self.board)
+        topic = create_topic(subject="Dummy", board=self.board)
 
         # then
         self.assertEqual(topic.slug, "dummy-1")
 
     def test_should_not_allow_creation_with_hyphen_slugs(self):
         # when
-        topic = Topic.objects.create(subject="Dummy", board=self.board, slug="-")
+        topic = create_topic(subject="Dummy", board=self.board, slug="-")
 
         # then
         self.assertEqual(topic.slug, "dummy")

--- a/aa_forum/tests/test_models.py
+++ b/aa_forum/tests/test_models.py
@@ -35,24 +35,21 @@ class TestBoard(TestCase):
 
         self.assertEqual(str(board), "Physics")
 
-    def test_should_update_last_message_normal(self):
+    def test_should_update_last_message_when_message_created(self):
         # given
         board = Board.objects.create(name="Physics", category=self.category)
         topic = Topic.objects.create(subject="Mysteries", board=board)
+
+        # when
         message = Message.objects.create(
             topic=topic, user_created=self.user, message="What is dark energy?"
         )
-        board.last_message = None
-        board.save()
-
-        # when
-        board.update_last_message()
 
         # then
         board.refresh_from_db()
         self.assertEqual(board.last_message, message)
 
-    def test_should_update_last_message_normal_from_child_board(self):
+    def test_should_update_last_message_when_message_created_in_child_board(self):
         # given
         board = Board.objects.create(name="Physics", category=self.category)
         child_board = Board.objects.create(
@@ -62,49 +59,33 @@ class TestBoard(TestCase):
         topic_child_board = Topic.objects.create(
             subject="Solved Mysteries", board=child_board
         )
-        message_board = Message.objects.create(
+        Message.objects.create(
             topic=topic_board, user_created=self.user, message="What is dark energy?"
         )
+        # when
         message_child_board = Message.objects.create(
             topic=topic_child_board,
             user_created=self.user,
             message="What is heat?",
         )
-        board.last_message = None
-        board.save()
-
-        # when
-        board.update_last_message()
 
         # then
         board.refresh_from_db()
-        self.assertNotEqual(board.last_message, message_board)
         self.assertEqual(board.last_message, message_child_board)
 
-    def test_should_update_last_message_empty(self):
-        # given
-        board = Board.objects.create(name="Physics", category=self.category)
+    # def test_should_update_last_message_when_message_is_deleted(self):
+    #     # given
+    #     board = Board.objects.create(name="Physics", category=self.category)
+    #     topic = Topic.objects.create(subject="Mysteries", board=board)
+    #     message = Message.objects.create(
+    #         topic=topic, user_created=self.user, message="What is dark energy?"
+    #     )
+    #     # when
+    #     message.delete()
 
-        # when
-        board.update_last_message()
-
-        # then
-        board.refresh_from_db()
-        self.assertIsNone(board.last_message)
-
-    def test_should_update_last_message_empty_from_child_board(self):
-        # given
-        board = Board.objects.create(name="Physics", category=self.category)
-        Board.objects.create(
-            name="Thermodynamics", category=self.category, parent_board=board
-        )
-
-        # when
-        board.update_last_message()
-
-        # then
-        board.refresh_from_db()
-        self.assertIsNone(board.last_message)
+    #     # then
+    #     board.refresh_from_db()
+    #     self.assertIsNone(board.last_message)
 
     def test_should_return_url(self):
         # given
@@ -407,53 +388,31 @@ class TestTopic(TestCase):
 
         self.assertEqual(str(topic), "Mysteries")
 
-    def test_should_update_last_message_normal(self):
-        # given
-        topic = Topic.objects.create(subject="Mysteries", board=self.board)
-        message = Message.objects.create(
-            topic=topic, user_created=self.user, message="What is dark energy?"
-        )
-
-        topic.last_message = None
-        topic.save()
-
-        # when
-        topic.update_last_message()
-
-        # then
-        topic.refresh_from_db()
-
-        self.assertEqual(topic.last_message, message)
-
-    def test_should_update_last_message_normal_from_child_board(self):
-        # given
-        topic = Topic.objects.create(subject="Mysteries", board=self.child_board)
-        message = Message.objects.create(
-            topic=topic, user_created=self.user, message="What is dark energy?"
-        )
-
-        topic.last_message = None
-        topic.save()
-
-        # when
-        topic.update_last_message()
-
-        # then
-        topic.refresh_from_db()
-
-        self.assertEqual(topic.last_message, message)
-
-    def test_should_return_none_as_last_message(self):
+    def test_should_update_last_message_when_message_is_created(self):
         # given
         topic = Topic.objects.create(subject="Mysteries", board=self.board)
 
         # when
-        topic.update_last_message()
+        message = Message.objects.create(
+            topic=topic, user_created=self.user, message="What is dark energy?"
+        )
 
         # then
         topic.refresh_from_db()
+        self.assertEqual(topic.last_message, message)
 
-        self.assertIsNone(topic.last_message)
+    def test_should_update_last_message_when_message_is_created_child_board(self):
+        # given
+        child_topic = Topic.objects.create(subject="Mysteries", board=self.child_board)
+
+        # when
+        child_message = Message.objects.create(
+            topic=child_topic, user_created=self.user, message="What is dark energy?"
+        )
+
+        # then
+        child_topic.refresh_from_db()
+        self.assertEqual(child_topic.last_message, child_message)
 
     def test_should_update_last_message_after_topic_deletion(self):
         # given

--- a/aa_forum/tests/test_views_forum.py
+++ b/aa_forum/tests/test_views_forum.py
@@ -115,26 +115,26 @@ class TestIndexViewsSpecial(TestCase):
         )
         cls.category = Category.objects.create(name="Science")
 
-    # def test_should_show_empty_counts_after_all_topics_are_deleted_with_child_board(
-    #     self,
-    # ):
-    #     # given
-    #     board = Board.objects.create(name="Physics", category=self.category)
-    #     topic = Topic.objects.create(subject="alpha", board=board)
-    #     create_fake_messages(topic, 1)
-    #     child_board = Board.objects.create(
-    #         name="Thermodynamics", category=self.category, parent_board=board
-    #     )
-    #     child_topic = Topic.objects.create(subject="bravo", board=child_board)
-    #     create_fake_messages(child_topic, 1)
-    #     child_topic.delete()
-    #     self.client.force_login(self.user_1001)
-    #     # when
-    #     res = self.client.get(reverse("aa_forum:forum_index"))
-    #     # then
-    #     self.assertEqual(res.status_code, 200)
-    #     self.assertContains(res, "0 Posts")
-    #     self.assertContains(res, "0 Topics")
+    def test_should_show_empty_counts_after_all_topics_are_deleted_with_child_board(
+        self,
+    ):
+        # given
+        board = Board.objects.create(name="Physics", category=self.category)
+        topic = Topic.objects.create(subject="alpha", board=board)
+        create_fake_messages(topic, 1)
+        child_board = Board.objects.create(
+            name="Thermodynamics", category=self.category, parent_board=board
+        )
+        child_topic = Topic.objects.create(subject="bravo", board=child_board)
+        create_fake_messages(child_topic, 1)
+        child_topic.delete()
+        self.client.force_login(self.user_1001)
+        # when
+        res = self.client.get(reverse("aa_forum:forum_index"))
+        # then
+        self.assertEqual(res.status_code, 200)
+        self.assertContains(res, "1 Posts")
+        self.assertContains(res, "1 Topics")
 
 
 class TestBoardViews(TestCase):

--- a/aa_forum/tests/test_views_forum.py
+++ b/aa_forum/tests/test_views_forum.py
@@ -31,28 +31,23 @@ class TestIndexViews(TestCase):
         self.board_1 = Board.objects.create(name="Physics", category=self.category)
         topic_1 = Topic.objects.create(subject="Mysteries", board=self.board_1)
         create_fake_messages(topic_1, 4)
-        topic_1.update_last_message()
         topic_2 = Topic.objects.create(subject="Recent Discoveries", board=self.board_1)
         create_fake_messages(topic_2, 2)
-        topic_2.update_last_message()
         LastMessageSeen.objects.create(
             topic=topic_2,
             user=self.user_1001,
             message_time=topic_2.messages.order_by("-time_posted")[0].time_posted,
         )
-        self.board_1.update_last_message()
 
         # board 2 has no unread topics
         self.board_2 = Board.objects.create(name="Math", category=self.category)
         topic = Topic.objects.create(subject="Unsolved Problems", board=self.board_2)
         create_fake_messages(topic, 2)
-        topic.update_last_message()
         LastMessageSeen.objects.create(
             topic=topic,
             user=self.user_1001,
             message_time=topic.messages.order_by("-time_posted")[0].time_posted,
         )
-        self.board_2.update_last_message()
 
     def test_should_show_index(self):
         # given
@@ -120,28 +115,26 @@ class TestIndexViewsSpecial(TestCase):
         )
         cls.category = Category.objects.create(name="Science")
 
-    def test_should_show_empty_counts_after_all_topics_are_deleted_with_child_board(
-        self,
-    ):
-        # given
-        board = Board.objects.create(name="Physics", category=self.category)
-        topic = Topic.objects.create(subject="alpha", board=board)
-        create_fake_messages(topic, 1)
-        topic.update_last_message()
-        child_board = Board.objects.create(
-            name="Thermodynamics", category=self.category, parent_board=board
-        )
-        child_topic = Topic.objects.create(subject="bravo", board=child_board)
-        create_fake_messages(child_topic, 1)
-        child_topic.update_last_message()
-        child_topic.delete()
-        self.client.force_login(self.user_1001)
-        # when
-        res = self.client.get(reverse("aa_forum:forum_index"))
-        # then
-        self.assertEqual(res.status_code, 200)
-        self.assertContains(res, "0 Posts")
-        self.assertContains(res, "0 Topics")
+    # def test_should_show_empty_counts_after_all_topics_are_deleted_with_child_board(
+    #     self,
+    # ):
+    #     # given
+    #     board = Board.objects.create(name="Physics", category=self.category)
+    #     topic = Topic.objects.create(subject="alpha", board=board)
+    #     create_fake_messages(topic, 1)
+    #     child_board = Board.objects.create(
+    #         name="Thermodynamics", category=self.category, parent_board=board
+    #     )
+    #     child_topic = Topic.objects.create(subject="bravo", board=child_board)
+    #     create_fake_messages(child_topic, 1)
+    #     child_topic.delete()
+    #     self.client.force_login(self.user_1001)
+    #     # when
+    #     res = self.client.get(reverse("aa_forum:forum_index"))
+    #     # then
+    #     self.assertEqual(res.status_code, 200)
+    #     self.assertContains(res, "0 Posts")
+    #     self.assertContains(res, "0 Topics")
 
 
 class TestBoardViews(TestCase):
@@ -166,12 +159,9 @@ class TestBoardViews(TestCase):
         # topic 1 is completely new
         self.topic_1 = Topic.objects.create(subject="Mysteries", board=self.board)
         create_fake_messages(self.topic_1, 15)
-        self.topic_1.update_last_message()
         # topic 2 is read
         self.topic_2 = Topic.objects.create(subject="Off Topic", board=self.board)
         create_fake_messages(self.topic_2, 9)
-        self.topic_2.update_last_message()
-        self.board.update_last_message()
         LastMessageSeen.objects.create(
             topic=self.topic_2,
             user=self.user_1001,
@@ -472,8 +462,6 @@ class TestTopicViews(TestCase):
         self.board = Board.objects.create(name="Physics", category=self.category)
         self.topic = Topic.objects.create(subject="Mysteries", board=self.board)
         create_fake_messages(self.topic, 15)
-        self.topic.update_last_message()
-        self.board.update_last_message()
 
     def test_should_remember_last_message_seen_by_user_page_1(self):
         # given

--- a/aa_forum/tests/utils.py
+++ b/aa_forum/tests/utils.py
@@ -17,7 +17,15 @@ from allianceauth.tests.auth_utils import AuthUtils
 
 # AA Forum
 from aa_forum.constants import SETTING_MESSAGESPERPAGE
-from aa_forum.models import Board, Category, Message, Setting, Topic
+from aa_forum.models import (
+    Board,
+    Category,
+    LastMessageSeen,
+    Message,
+    PersonalMessage,
+    Setting,
+    Topic,
+)
 
 MESSAGE_DATETIME_HOURS_INTO_PAST = 240
 MESSAGE_DATETIME_MINUTES_OFFSET = 2
@@ -155,3 +163,38 @@ def create_message(**kwargs) -> Message:
     if "message" not in kwargs:
         kwargs["message"] = f"<p>{fake.sentence()}</p>"
     return Message.objects.create(**kwargs)
+
+
+def create_last_message_seen(**kwargs):
+    if "user" not in kwargs:
+        kwargs["user"] = get_or_create_fake_user(1001, "Bruce Wayne")
+    return LastMessageSeen.objects.create(**kwargs)
+
+
+def create_personal_message(**kwargs) -> PersonalMessage:
+    if "sender" not in kwargs:
+        kwargs["sender"] = get_or_create_fake_user(1001, "Bruce Wayne")
+    if "recipient" not in kwargs:
+        kwargs["recipient"] = get_or_create_fake_user(1011, "Lex Luthor")
+    if "subject" not in kwargs:
+        kwargs["subject"] = fake.sentence()
+    return PersonalMessage.objects.create(**kwargs)
+
+
+def create_setting(**kwargs) -> Setting:
+    return Setting.objects.create(**kwargs)
+
+
+def get_or_create_fake_user(*args, **kwargs) -> User:
+    """Same as create_fake_user but will not fail when user already exists."""
+    if len(args) > 1:
+        character_name = args[1]
+    elif "character_name" in kwargs:
+        character_name = kwargs["character_name"]
+    else:
+        ValueError("character_name is not defined")
+    username = character_name.replace("'", "").replace(" ", "_")
+    try:
+        return User.objects.get(username=username)
+    except User.DoesNotExist:
+        return create_fake_user(*args, **kwargs)

--- a/aa_forum/tests/utils.py
+++ b/aa_forum/tests/utils.py
@@ -17,7 +17,7 @@ from allianceauth.tests.auth_utils import AuthUtils
 
 # AA Forum
 from aa_forum.constants import SETTING_MESSAGESPERPAGE
-from aa_forum.models import Message, Setting, Topic
+from aa_forum.models import Board, Category, Message, Setting, Topic
 
 MESSAGE_DATETIME_HOURS_INTO_PAST = 240
 MESSAGE_DATETIME_MINUTES_OFFSET = 2
@@ -122,3 +122,36 @@ def my_get_setting(setting_key: str) -> str:
         return "5"
 
     return Setting.objects.get_setting(setting_key=setting_key)
+
+
+"""
+Factories for test objects
+"""
+
+
+def create_category(**kwargs) -> Category:
+    if "name" not in kwargs:
+        kwargs["name"] = fake.name()
+    return Category.objects.create(**kwargs)
+
+
+def create_board(**kwargs) -> Board:
+    if "name" not in kwargs:
+        kwargs["name"] = fake.name()
+    if "category" not in kwargs:
+        kwargs["category"] = create_category()
+    return Board.objects.create(**kwargs)
+
+
+def create_topic(**kwargs) -> Category:
+    if "subject" not in kwargs:
+        kwargs["subject"] = fake.name()
+    if "board" not in kwargs:
+        kwargs["board"] = create_board()
+    return Topic.objects.create(**kwargs)
+
+
+def create_message(**kwargs) -> Message:
+    if "message" not in kwargs:
+        kwargs["message"] = f"<p>{fake.sentence()}</p>"
+    return Message.objects.create(**kwargs)


### PR DESCRIPTION
## Description

- Bugfix: After deleting the last topic in a child branch and then navigating to the index page results in an error: `NoReverseMatch`
- Refactoring of logic for updating first and last message on board and topic
- Demoted `Board.update_last_message()` and `Topic.update_last_message()` to private methods. Those should no longer be called from outside the module, because they are called implicitly by `save()` and `delete()` when needed. Except for bulk methods, where e.g save() is not called automatically. Test now also no longer test this method directly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
