### PR TITLE
Next Version - v1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [In development] - Unreleased
 
+
+## [1.4.3] - 2022-01-24
+
 ### Fixed
 
 - `NoReverseMatch` error when slugs for category, board or topic that are generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [In development] - Unreleased
 
+### Fixed
+
+- `NoReverseMatch` error when slugs for category, board or topic that are generated
+  from the name/subject ended up being empty when only entered special chars like
+  "@#$%" as name/subject
+
 
 ## [1.4.2] - 2022-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [In development] - Unreleased
 
+
+## [1.4.2] - 2022-01-23
+
 ### Fixed
 
-- Deleting last topic of a child board results in NoReverseMatch error on index page
+- Deleting the last topic of a child board results in a `NoReverseMatch` error on
+  the index page (Thanks @ErikKalkoken)
+
+### Changed
+
+- Refactoring of logic for updating first and last message on board and topic
+  (Thanks @ErikKalkoken)
+- Demoted `Board.update_last_message()` and `Topic.update_last_message()` to private
+  methods. Those should no longer be called from outside the module, because they
+  are called implicitly by `save()` and `delete()` when needed. Except for bulk
+  methods, where e.g. `save()` is not called automatically. Test now also no longer
+  test this method directly. (Thanks @ErikKalkoken)
+
 
 ## [1.4.1] - 2022-01-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- `NoReverseMatch` error when slugs for category, board or topic that are generated
+- `NoReverseMatch` error when slugs for a category, board or topic that are generated
   from the name/subject ended up being empty when only entered special chars like
   "@#$%" as name/subject
 

--- a/aa_forum/__init__.py
+++ b/aa_forum/__init__.py
@@ -4,5 +4,5 @@ A couple of variables to use throughout the app
 
 default_app_config: str = "aa_forum.apps.AaForumConfig"
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"
 __title__ = "Forum"

--- a/aa_forum/__init__.py
+++ b/aa_forum/__init__.py
@@ -4,5 +4,5 @@ A couple of variables to use throughout the app
 
 default_app_config: str = "aa_forum.apps.AaForumConfig"
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 __title__ = "Forum"

--- a/aa_forum/models.py
+++ b/aa_forum/models.py
@@ -128,6 +128,12 @@ class Category(models.Model):
 
         super().save(*args, **kwargs)
 
+        if self.slug == "":
+            self.slug = _generate_slug(
+                type(self), f"{self.__class__.__name__} {self.pk}"
+            )
+            self.save()
+
 
 class Board(models.Model):
     """
@@ -209,6 +215,12 @@ class Board(models.Model):
             self.slug = _generate_slug(type(self), self.name)
 
         super().save(*args, **kwargs)
+
+        if self.slug == "":
+            self.slug = _generate_slug(
+                type(self), f"{self.__class__.__name__} {self.pk}"
+            )
+            self.save()
 
     def get_absolute_url(self) -> str:
         """
@@ -313,6 +325,13 @@ class Topic(models.Model):
             self.slug = _generate_slug(type(self), self.subject)
 
         super().save(*args, **kwargs)
+
+        if self.slug == "":
+            self.slug = _generate_slug(
+                type(self), f"{self.__class__.__name__} {self.pk}"
+            )
+            self.save()
+
         if board_needs_update:
             self.board._update_message_references()
 

--- a/aa_forum/tests/test_models.py
+++ b/aa_forum/tests/test_models.py
@@ -91,20 +91,6 @@ class TestBoard(TestCase):
         board.refresh_from_db()
         self.assertEqual(board.last_message, message_child_board)
 
-    # def test_should_update_last_message_when_message_is_deleted(self):
-    #     # given
-    #     board = create_board(name="Physics", category=self.category)
-    #     topic = create_topic(subject="Mysteries", board=board)
-    #     message = create_message(
-    #         topic=topic, user_created=self.user, message="What is dark energy?"
-    #     )
-    #     # when
-    #     message.delete()
-
-    #     # then
-    #     board.refresh_from_db()
-    #     self.assertIsNone(board.last_message)
-
     def test_should_return_url(self):
         # given
         board = create_board(category=self.category, name="Physics")
@@ -200,6 +186,20 @@ class TestBoard(TestCase):
         # then
         self.assertEqual(category.slug, "hyphen")
 
+    def test_should_handle_empty_board_slug(self):
+        """
+        Handling an empty slug that is returned by Board.save() when the board name is
+        just special characters, which are getting stripped by slug generation
+        :return:
+        """
+
+        # when
+        board = create_board(name="@#$%", category=self.category)
+
+        # then
+        expected_slug = f"{board.__class__.__name__}-{board.pk}".lower()
+        self.assertEqual(board.slug, expected_slug)
+
 
 class TestCategory(TestCase):
     @classmethod
@@ -269,6 +269,20 @@ class TestCategory(TestCase):
 
         # then
         self.assertEqual(category.slug, "hyphen")
+
+    def test_should_handle_empty_category_slug(self):
+        """
+        Handling an empty slug that is returned by Category.save() when the category
+        name is just special characters, which are getting stripped by slug generation
+        :return:
+        """
+
+        # when
+        category = create_category(name="@#$%")
+
+        # then
+        expected_slug = f"{category.__class__.__name__}-{category.pk}".lower()
+        self.assertEqual(category.slug, expected_slug)
 
 
 @patch(MODELS_PATH + ".Setting.objects.get_setting", new=my_get_setting)
@@ -623,10 +637,24 @@ class TestTopic(TestCase):
     @patch(MODELS_PATH + ".INTERNAL_URL_PREFIX", "-")
     def test_should_create_slug_with_name_matching_internal_url_prefix(self):
         # when
-        category = create_topic(subject="-", board=self.board)
+        topic = create_topic(subject="-", board=self.board)
 
         # then
-        self.assertEqual(category.slug, "hyphen")
+        self.assertEqual(topic.slug, "hyphen")
+
+    def test_should_handle_empty_topic_slug(self):
+        """
+        Handling an empty slug that is returned by Topic.save() when the topic
+        name is just special characters, which are getting stripped by slug generation
+        :return:
+        """
+
+        # when
+        topic = create_topic(subject="@#$%", board=self.board)
+
+        # then
+        expected_slug = f"{topic.__class__.__name__}-{topic.pk}".lower()
+        self.assertEqual(topic.slug, expected_slug)
 
 
 class TestPersonalMessage(TestCase):


### PR DESCRIPTION
## Description

### Fixed

- `NoReverseMatch` error when slugs for a category, board or topic that are generated
  from the name/subject ended up being empty when only entered special chars like
  "@#$%" as name/subject


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
