### PR TITLE
Release v1.6.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
         args: ['--maxkb=1000']
       - id: check-ast  # Is it valid Python?
       - id: debug-statements  # Check for debugger imports and py37+ breakpoint() calls
+      - id: check-merge-conflict
 
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
     rev: 2.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,12 @@ repos:
       - id: end-of-file-fixer
         exclude: \.(min\.css|min\.js|po|mo)$
       - id: mixed-line-ending
-        args: [ '--fix=lf' ]
+        args: [ --fix=lf ]
       - id: fix-encoding-pragma
-        args: [ '--remove' ]
+        args: [ --remove ]
       - id: detect-private-key
       - id: check-added-large-files
-        args: ['--maxkb=1000']
+        args: [ --maxkb=1000 ]
       - id: check-ast  # Is it valid Python?
       - id: debug-statements  # Check for debugger imports and py37+ breakpoint() calls
       - id: check-merge-conflict
@@ -55,12 +55,12 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.0
+    rev: v1.12.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [ black==21.12b0 ]
+        additional_dependencies: [ black==22.1.0 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [In development] - Unreleased
 
+
+## [1.6.0] - 2022-02-28
+
 ### Fixed
 
 - Compatibility Fixes (AA 3.x / Django 4):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [In development] - Unreleased
 
+### Fixed
+
+- [Compatibility] AA 3.x / Django 4 :: ImportError: cannot import name
+  'ugettext_lazy' from 'django.utils.translation'
+
 
 ## [1.5.1] - 2022-01-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- [Compatibility] AA 3.x / Django 4 :: ImportError: cannot import name
-  'ugettext_lazy' from 'django.utils.translation'
+- Compatibility Fixes (AA 3.x / Django 4):
+  - ImportError: cannot import name 'ugettext_lazy' from 'django.utils.translation'
+  - URL config in README updated to work with Django 4. **Please make sure to update
+    your configuration accordingly!**
 
 
 ## [1.5.1] - 2022-01-26

--- a/README.md
+++ b/README.md
@@ -264,7 +264,6 @@ following block right before the `handler` definitions:
 from django.apps import apps
 
 if apps.is_installed("ckeditor"):
-    from django.urls import re_path
     from django.contrib.auth.decorators import login_required
     from django.views.decorators.cache import never_cache
     from ckeditor_uploader import views as ckeditor_views
@@ -284,19 +283,19 @@ if apps.is_installed("ckeditor"):
 After this, your `urls.py` should look similar to this:
 
 ```python
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import re_path
 from allianceauth import urls
 
 # Alliance auth urls
 urlpatterns = [
-    url(r"", include(urls)),
+    re_path(r"", include(urls)),
 ]
 
 # URL configuration for cKeditor
 from django.apps import apps
 
 if apps.is_installed("ckeditor"):
-    from django.urls import re_path
     from django.contrib.auth.decorators import login_required
     from django.views.decorators.cache import never_cache
     from ckeditor_uploader import views as ckeditor_views

--- a/README.md
+++ b/README.md
@@ -283,8 +283,8 @@ if apps.is_installed("ckeditor"):
 After this, your `urls.py` should look similar to this:
 
 ```python
-from django.conf.urls import include
-from django.urls import re_path
+from django.urls import include, re_path
+
 from allianceauth import urls
 
 # Alliance auth urls

--- a/aa_forum/__init__.py
+++ b/aa_forum/__init__.py
@@ -4,5 +4,5 @@ A couple of variables to use throughout the app
 
 default_app_config: str = "aa_forum.apps.AaForumConfig"
 
-__version__ = "1.5.1"
+__version__ = "1.6.0"
 __title__ = "Forum"

--- a/aa_forum/auth_hooks.py
+++ b/aa_forum/auth_hooks.py
@@ -3,7 +3,7 @@ Hook into AA
 """
 
 # Django
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # Alliance Auth
 from allianceauth import hooks

--- a/aa_forum/forms.py
+++ b/aa_forum/forms.py
@@ -10,7 +10,7 @@ from django import forms
 from django.contrib.auth.models import Group
 from django.forms import ModelForm
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # AA Forum
 from aa_forum.models import Board, Category, Message, Topic

--- a/testauth/urls.py
+++ b/testauth/urls.py
@@ -1,25 +1,31 @@
-# Third Party
-from ckeditor_uploader import views
-
 # Django
-from django.conf.urls import include, url
-from django.contrib.auth.decorators import login_required
-
-# *** New Imports for cKeditor
-from django.urls import re_path
-from django.views.decorators.cache import never_cache
+from django.apps import apps
+from django.urls import include, re_path
 
 # Alliance Auth
 from allianceauth import urls
 
+# Alliance auth urls
 urlpatterns = [
-    # *** New URL override for cKeditor BEFORE THE MAIN IMPORT
-    re_path(r"^upload/", login_required(views.upload), name="ckeditor_upload"),
-    re_path(
-        r"^browse/",
-        never_cache(login_required(views.browse)),
-        name="ckeditor_browse",
-    ),
-    # Alliance Auth URLs
-    url(r"", include(urls)),
+    re_path(r"", include(urls)),
 ]
+
+# URL configuration for cKeditor
+if apps.is_installed("ckeditor"):
+    # Third Party
+    from ckeditor_uploader import views as ckeditor_views
+
+    # Django
+    from django.contrib.auth.decorators import login_required
+    from django.views.decorators.cache import never_cache
+
+    urlpatterns = [
+        re_path(
+            r"^upload/", login_required(ckeditor_views.upload), name="ckeditor_upload"
+        ),
+        re_path(
+            r"^browse/",
+            never_cache(login_required(ckeditor_views.browse)),
+            name="ckeditor_browse",
+        ),
+    ] + urlpatterns

--- a/tox.ini
+++ b/tox.ini
@@ -30,5 +30,5 @@ install_command = python -m pip install -U {opts} {packages}
 
 commands=
     coverage run runtests.py aa_forum -v 2
-    coverage report
+    coverage report -m
     coverage xml


### PR DESCRIPTION
## Description

### Fixed

- Compatibility Fixes (AA 3.x / Django 4):
  - ImportError: cannot import name 'ugettext_lazy' from 'django.utils.translation'
  - URL config in README updated to work with Django 4. **Please make sure to update
    your configuration accordingly!**


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
