### PR TITLE
[FIX] Only show on reply, not on modify

### DIFF
--- a/aa_forum/templates/aa_forum/partials/forum/topic/modify-message.html
+++ b/aa_forum/templates/aa_forum/partials/forum/topic/modify-message.html
@@ -18,7 +18,7 @@
         <form id="aa-forum-form-message-modify" autocomplete="off" action="{% url 'aa_forum:forum_message_modify' board.category.slug board.slug message.topic.slug message.pk %}" method="post">
             {% csrf_token %}
 
-            {% bootstrap_form form %}
+            {% bootstrap_field form.message %}
 
             {% include "aa_forum/partials/form/required-field-hint.html" %}
 


### PR DESCRIPTION
## Description

### Fixed

- Show close/re-open checkboxes only on reply, not on modify

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
