### PR TITLE
[REMOVE] Intigrety hash from CKEditor CSS, since we don't control it

### DIFF
--- a/aa_forum/templates/aa_forum/bundles/ckeditor5-css.html
+++ b/aa_forum/templates/aa_forum/bundles/ckeditor5-css.html
@@ -1,9 +1,3 @@
 {% load static %}
 
-<link
-    href="{% static 'django_ckeditor_5/dist/styles.css' %}"
-    integrity="sha512-eKzBJmZ8bECH46pIMf8XOXdxW0kTbJUx2suem5UUaWZHOXzTRSf0M89gJ9v94MVLe8Ga/u1QlcLCBUd5O5O6hw=="
-    crossorigin="anonymous"
-    media="all"
-    rel="stylesheet"
->
+<link href="{% static 'django_ckeditor_5/dist/styles.css' %}" media="all" rel="stylesheet">


### PR DESCRIPTION
## Description

### Removed

- Integrity hash from CKEditor CSS, since we don't control it

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have checked my code and corrected any misspellings
