### PR TITLE
[ADD] Missing tooltip for `topic.has_unread_messages` marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+### Added
+
+- Missing tooltip for `topic.has_unread_messages` marker
+
 ## \[2.2.1\] - 2024-05-16
 
 ### Changed

--- a/aa_forum/templates/aa_forum/partials/forum/board/topic.html
+++ b/aa_forum/templates/aa_forum/partials/forum/board/topic.html
@@ -25,6 +25,8 @@
                         id="aa-forum-link-new-{{ topic.id }}"
                         href="{% url 'aa_forum:forum_topic_first_unread_message' topic.board.category.slug topic.board.slug topic.slug %}"
                         class="badge bg-warning label-aa-forum-topic-new-message ms-2"
+                        title="{% translate 'Go to first unread message' %}"
+                        data-bs-tooltip="aa-forum"
                     >
                         {% translate "New" %}
                     </a>


### PR DESCRIPTION
## Description

### Added

- Missing tooltip for `topic.has_unread_messages` marker

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
