### PR TITLE
[CHANGE] Switched to `django-solo` to provide the Singleton model

### DIFF
--- a/.make/conf.d/django.mk
+++ b/.make/conf.d/django.mk
@@ -40,10 +40,24 @@ compile_translations:
 		-l uk \
 		-l zh_Hans
 
+# Migrate all database changes
+.PHONY: migrate
+migrate:
+	@echo "Migrating the database"
+	@python ../myauth/manage.py migrate $(package)
+
+# Make migrations for the app
+.PHONY: migrations
+migrations:
+	@echo "Creating or updating migrations"
+	@python ../myauth/manage.py makemigrations $(package)
+
 # Help message
 .PHONY: help
 help::
 	@echo "  $(TEXT_UNDERLINE)Translation:$(TEXT_UNDERLINE_END)"
+	@echo "    migrate                   Migrate all database changes"
+	@echo "    migrations                Create or update migrations"
 	@echo "    translations              Create or update translation files"
 	@echo "    compile_translations      Compile translation files"
 	@echo ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+### Changed
+
+- Switch to `django-solo` to provide the singleton for the settings model, instead of the custom implementation
+
 ## \[2.7.0\] - 2024-09-16
 
 ### Changed

--- a/aa_forum/admin.py
+++ b/aa_forum/admin.py
@@ -2,65 +2,15 @@
 AA Forum Admin
 """
 
+# Third Party
+from solo.admin import SingletonModelAdmin
+
 # Django
 from django.contrib import admin
 from django.utils.safestring import mark_safe
 
 # AA Forum
 from aa_forum.models import Board, Category, Setting, Topic, UserProfile
-
-
-class SingletonModelAdmin(admin.ModelAdmin):
-    """
-    Singleton Model Admin
-    Prevents Django admin users deleting the singleton or adding extra rows.
-    """
-
-    actions = None  # Removes the default delete action.
-
-    def has_add_permission(self, request):  # pylint: disable=unused-argument
-        """
-        Has "add" permissions
-
-        :param request:
-        :type request:
-        :return:
-        :rtype:
-        """
-
-        return self.model.objects.all().count() == 0
-
-    def has_change_permission(
-        self, request, obj=None  # pylint: disable=unused-argument
-    ):
-        """
-        Has "change" permissions
-
-        :param request:
-        :type request:
-        :param obj:
-        :type obj:
-        :return:
-        :rtype:
-        """
-
-        return True
-
-    def has_delete_permission(
-        self, request, obj=None  # pylint: disable=unused-argument
-    ):
-        """
-        Has "delete" permissions
-
-        :param request:
-        :type request:
-        :param obj:
-        :type obj:
-        :return:
-        :rtype:
-        """
-
-        return False
 
 
 class BaseReadOnlyAdminMixin:

--- a/aa_forum/models.py
+++ b/aa_forum/models.py
@@ -7,6 +7,7 @@ import math
 
 # Third Party
 import unidecode
+from solo.models import SingletonModel
 
 # Django
 from django.contrib.auth.models import Group, Permission, User
@@ -82,48 +83,6 @@ def _generate_slug(calling_model: models.Model, name: str) -> str:
         )
 
     return slug_name
-
-
-class SingletonModel(models.Model):
-    """
-    SingletonModel
-    """
-
-    class Meta:  # pylint: disable=too-few-public-methods
-        """
-        Model meta definitions
-        """
-
-        abstract = True
-
-    def save(self, *args, **kwargs):
-        """
-        "Save" action
-
-        :param args:
-        :type args:
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
-        """
-
-        self.pk = 1
-        super().save(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        """
-        "Delete" action
-
-        :param args:
-        :type args:
-        :param kwargs:
-        :type kwargs:
-        :return:
-        :rtype:
-        """
-
-        pass  # pylint: disable=unnecessary-pass
 
 
 class General(models.Model):


### PR DESCRIPTION
## Description

### Changed

- Switch to `django-solo` to provide the singleton for the settings model, instead of the custom implementation

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
