### PR TITLE
[CHANGE] Dependency update: `django-ckeditor-5`>=0.2.14 (Fixing #219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ Section Order:
 - Improve oEmbed handling
 - Improve internal forms handling
 - URL config modularized
+- Dependency updates
+  - `django-ckeditor-5`>=0.2.14 (Fixing #219)
+
+Remember to add the following to your `local.py`, so your users can upload files:
+
+```python
+CKEDITOR_5_FILE_UPLOAD_PERMISSION = (
+    "authenticated"  # Possible values: "staff", "authenticated", "any"
+)
+```
 
 ## \[2.8.0\] - 2024-09-19
 

--- a/README.md
+++ b/README.md
@@ -147,12 +147,9 @@ INSTALLED_APPS += [
 # Django CKEditor 5 Configuration
 if "django_ckeditor_5" in INSTALLED_APPS:
     # CKEditor 5 File Upload Configuration
-    # Permissions not yet implemented by Django CKEditor 5, but it's coming …
-    # CKEDITOR_5_FILE_UPLOAD_PERMISSION = (
-    #    "authenticated"  # Possible values: "staff", "authenticated", "any"
-    # )
-    # Add more image upload file types if needed
-    CKEDITOR_5_UPLOAD_FILE_TYPES = ["jpg", "jpeg", "png", "gif", "bmp", "webp", "tiff"]
+    CKEDITOR_5_FILE_UPLOAD_PERMISSION = (
+        "authenticated"  # Possible values: "staff", "authenticated", "any"
+    )
 
     MEDIA_URL = "/media/uploads/"
     MEDIA_ROOT = "/var/www/myauth/media/uploads"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "allianceauth<5,>=4.3.1",
     "allianceauth-app-utils>=1.24",
     "dhooks-lite>=1.1",
-    "django-ckeditor-5>=0.2.13",
+    "django-ckeditor-5>=0.2.14",
     "unidecode>=1.3.7",
 ]
 optional-dependencies.tests-allianceauth-latest = [


### PR DESCRIPTION
## Description

### Changed

- Dependency updates
  - `django-ckeditor-5`>=0.2.14

Remember to add the following to your `local.py`, so your users can upload files:

```python
CKEDITOR_5_FILE_UPLOAD_PERMISSION = (
    "authenticated"  # Possible values: "staff", "authenticated", "any"
)
```

Fixes #219 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
