### PR TITLE
[CHANGE] Enable form validation for CKEditor fields, where needed

### DIFF
--- a/.github/workflows/automated-checks.yml
+++ b/.github/workflows/automated-checks.yml
@@ -37,7 +37,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           # https://endoflife.date/nodejs
-          node-version: '20' # [LTS] End of Life: 30 Apr 2026
+          node-version: 22 # [LTS] End of Life: 30 Apr 2027
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
       - run: npm install
 
       - name: Run Pre Commit Checks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@
 default_language_version:
   # force all unspecified python hooks to run python3
   python: python3
+  node: 22.4.1
 
 # https://pre-commit.ci/
 ci:
@@ -132,6 +133,7 @@ repos:
       - id: eslint
         name: ESLint
         description: Check for problems in JavaScript files.
+        language: node
         exclude: |
           (?x)(
             .min(.js|.js.map)|
@@ -148,6 +150,7 @@ repos:
       - id: stylelint
         name: Stylelint
         description: Check for problems in CSS files.
+        language: node
         exclude: |
           (?x)(
             .min(.css|.css.map)|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Section Order:
 ### Security
 -->
 
+### Changed
+
+- Enable form validation for CKEditor fields, where needed
+- Dependency updates
+  - `django-ckeditor-5`>=0.2.15
+
 ## \[2.8.1\] - 2024-10-13
 
 ### Changed

--- a/aa_forum/forms.py
+++ b/aa_forum/forms.py
@@ -16,7 +16,7 @@ from django_ckeditor_5.widgets import CKEditor5Widget
 
 # AA Forum
 from aa_forum.app_settings import discord_messaging_proxy_available
-from aa_forum.helper.text import string_cleanup
+from aa_forum.helper.text import string_cleanup, strip_html_tags
 from aa_forum.models import (
     Board,
     Category,
@@ -122,6 +122,7 @@ class NewTopicForm(ModelForm):
                 "style": "width: 100%;",
             },
         ),
+        required=False,  # We have to set this to False, otherwise CKEditor5 will not work
         label=get_mandatory_form_label_text(text=_("Message")),
     )
 
@@ -148,7 +149,13 @@ class NewTopicForm(ModelForm):
 
         cleaned_data = super().clean()
 
-        if not string_cleanup(cleaned_data.get("message")).strip():
+        if (
+            cleaned_data.get("message")
+            and strip_html_tags(
+                text=string_cleanup(cleaned_data.get("message")), strip_nbsp=True
+            ).strip()
+            == ""
+        ):
             raise ValidationError(_("You have forgotten the message!"))
 
         return cleaned_data
@@ -162,6 +169,9 @@ class NewTopicForm(ModelForm):
         """
 
         message = string_cleanup(string=self.cleaned_data["message"])
+
+        if not message:
+            raise ValidationError(_("You have forgotten the message!"))
 
         return message
 
@@ -331,6 +341,21 @@ class EditMessageForm(ModelForm):
         ),
     )
 
+    def __init__(self, *args, **kwargs):
+        """
+        When form is initialized
+
+        :param args:
+        :type args:
+        :param kwargs:
+        :type kwargs:
+        """
+
+        super().__init__(*args, **kwargs)
+
+        # We have to set this to False, otherwise CKEditor5 will not work
+        self.fields["message"].required = False
+
     class Meta:  # pylint: disable=too-few-public-methods
         """
         Meta definitions
@@ -351,7 +376,13 @@ class EditMessageForm(ModelForm):
 
         cleaned_data = super().clean()
 
-        if not string_cleanup(cleaned_data.get("message")).strip():
+        if (
+            cleaned_data.get("message")
+            and strip_html_tags(
+                text=string_cleanup(cleaned_data.get("message")), strip_nbsp=True
+            ).strip()
+            == ""
+        ):
             raise ValidationError(_("You have forgotten the message!"))
 
         return cleaned_data
@@ -365,6 +396,9 @@ class EditMessageForm(ModelForm):
         """
 
         message = string_cleanup(string=self.cleaned_data["message"])
+
+        if not message:
+            raise ValidationError(_("You have forgotten the message!"))
 
         return message
 
@@ -381,10 +415,6 @@ class UserProfileForm(ModelForm):
 
         model = UserProfile
 
-        max_signature_length = Setting.objects.get_setting(
-            setting_key=Setting.Field.USERSIGNATURELENGTH
-        )
-
         fields = [
             "signature",
             "website_title",
@@ -393,9 +423,7 @@ class UserProfileForm(ModelForm):
             "show_unread_topics_dashboard_widget",
         ]
         help_texts = {
-            "signature": _(
-                f"Your signature will appear below your posts. (Max. {max_signature_length} characters.)"  # pylint: disable=line-too-long
-            ),
+            "signature": _("Your signature will appear below your posts."),
             "website_title": _("Your website's title."),
             "website_url": _(
                 "Your website's URL. (Don't forget to also set a title for your "
@@ -532,6 +560,7 @@ class NewPersonalMessageForm(ModelForm):
         super().__init__(*args, **kwargs)
 
         self.fields["recipient"].queryset = General.users_with_basic_access()
+        self.fields["message"].required = False
 
     class Meta:  # pylint: disable=too-few-public-methods
         """
@@ -558,7 +587,13 @@ class NewPersonalMessageForm(ModelForm):
 
         cleaned_data = super().clean()
 
-        if not string_cleanup(cleaned_data.get("message")).strip():
+        if (
+            cleaned_data.get("message")
+            and strip_html_tags(
+                text=string_cleanup(cleaned_data.get("message")), strip_nbsp=True
+            ).strip()
+            == ""
+        ):
             raise ValidationError(_("You have forgotten the message!"))
 
         return cleaned_data
@@ -573,6 +608,9 @@ class NewPersonalMessageForm(ModelForm):
 
         message = string_cleanup(string=self.cleaned_data["message"])
 
+        if not message:
+            raise ValidationError(_("You have forgotten the message!"))
+
         return message
 
 
@@ -580,6 +618,18 @@ class ReplyPersonalMessageForm(ModelForm):
     """
     Reply to personal message form
     """
+
+    def __init__(self, *args, **kwargs):
+        """
+        When form is initialized
+
+        :param args:
+        :param kwargs:
+        """
+
+        super().__init__(*args, **kwargs)
+
+        self.fields["message"].required = False
 
     class Meta:  # pylint: disable=too-few-public-methods
         """
@@ -601,7 +651,13 @@ class ReplyPersonalMessageForm(ModelForm):
 
         cleaned_data = super().clean()
 
-        if not string_cleanup(cleaned_data.get("message")).strip():
+        if (
+            cleaned_data.get("message")
+            and strip_html_tags(
+                text=string_cleanup(cleaned_data.get("message")), strip_nbsp=True
+            ).strip()
+            == ""
+        ):
             raise ValidationError(_("You have forgotten the message!"))
 
         return cleaned_data
@@ -615,5 +671,8 @@ class ReplyPersonalMessageForm(ModelForm):
         """
 
         message = string_cleanup(string=self.cleaned_data["message"])
+
+        if not message:
+            raise ValidationError(_("You have forgotten the message!"))
 
         return message

--- a/aa_forum/forms.py
+++ b/aa_forum/forms.py
@@ -111,6 +111,7 @@ class NewTopicForm(ModelForm):
     New topic form
     """
 
+    # Non-model field, so we have to define it here and not in the Meta class.
     message = forms.CharField(
         widget=CKEditor5Widget(
             config_name="extends",
@@ -121,7 +122,6 @@ class NewTopicForm(ModelForm):
                 "style": "width: 100%;",
             },
         ),
-        required=False,  # We have to set this to False, otherwise CKEditor5 will not work
         label=get_mandatory_form_label_text(text=_("Message")),
     )
 
@@ -331,21 +331,6 @@ class EditMessageForm(ModelForm):
         ),
     )
 
-    def __init__(self, *args, **kwargs):
-        """
-        When form is initialized
-
-        :param args:
-        :type args:
-        :param kwargs:
-        :type kwargs:
-        """
-
-        super().__init__(*args, **kwargs)
-
-        # We have to set this to False, otherwise CKEditor5 will not work
-        self.fields["message"].required = False
-
     class Meta:  # pylint: disable=too-few-public-methods
         """
         Meta definitions
@@ -396,6 +381,10 @@ class UserProfileForm(ModelForm):
 
         model = UserProfile
 
+        max_signature_length = Setting.objects.get_setting(
+            setting_key=Setting.Field.USERSIGNATURELENGTH
+        )
+
         fields = [
             "signature",
             "website_title",
@@ -404,7 +393,9 @@ class UserProfileForm(ModelForm):
             "show_unread_topics_dashboard_widget",
         ]
         help_texts = {
-            "signature": _("Your signature will appear below your posts."),
+            "signature": _(
+                f"Your signature will appear below your posts. (Max. {max_signature_length} characters.)"  # pylint: disable=line-too-long
+            ),
             "website_title": _("Your website's title."),
             "website_url": _(
                 "Your website's URL. (Don't forget to also set a title for your "
@@ -541,7 +532,6 @@ class NewPersonalMessageForm(ModelForm):
         super().__init__(*args, **kwargs)
 
         self.fields["recipient"].queryset = General.users_with_basic_access()
-        self.fields["message"].required = False
 
     class Meta:  # pylint: disable=too-few-public-methods
         """
@@ -588,20 +578,8 @@ class NewPersonalMessageForm(ModelForm):
 
 class ReplyPersonalMessageForm(ModelForm):
     """
-    Reply personal message form
+    Reply to personal message form
     """
-
-    def __init__(self, *args, **kwargs):
-        """
-        When form is initialized
-
-        :param args:
-        :param kwargs:
-        """
-
-        super().__init__(*args, **kwargs)
-
-        self.fields["message"].required = False
 
     class Meta:  # pylint: disable=too-few-public-methods
         """

--- a/aa_forum/helper/text.py
+++ b/aa_forum/helper/text.py
@@ -96,22 +96,48 @@ def string_cleanup(string: str) -> str:
     :rtype:
     """
 
-    re_head = re.compile(
-        pattern=r"<\s*head[^>]*>.*?<\s*/\s*head\s*>", flags=re.S | re.I
-    )
-    re_script = re.compile(
-        pattern=r"<\s*script[^>]*>.*?<\s*/\s*script\s*>", flags=re.S | re.I
-    )
-    re_css = re.compile(
-        pattern=r"<\s*style[^>]*>.*?<\s*/\s*style\s*>", flags=re.S | re.I
-    )
+    if string:
+        re_head = re.compile(
+            pattern=r"<\s*head[^>]*>.*?<\s*/\s*head\s*>", flags=re.S | re.I
+        )
+        re_script = re.compile(
+            pattern=r"<\s*script[^>]*>.*?<\s*/\s*script\s*>", flags=re.S | re.I
+        )
+        re_css = re.compile(
+            pattern=r"<\s*style[^>]*>.*?<\s*/\s*style\s*>", flags=re.S | re.I
+        )
 
-    # Strip JS
-    string = re_head.sub(repl="", string=string)
-    string = re_script.sub(repl="", string=string)
-    string = re_css.sub(repl="", string=string)
+        # Strip JS
+        string = re_head.sub(repl="", string=string)
+        string = re_script.sub(repl="", string=string)
+        string = re_css.sub(repl="", string=string)
+
+    logger.debug(msg=f"Cleaned up string: {string}")
 
     return string
+
+
+def strip_html_tags(text: str, strip_nbsp: bool = False) -> str:
+    """
+    Strip HTML tags from a text
+
+    :param text: The text to strip HTML tags from
+    :type text: str
+    :param strip_nbsp: Whether to strip &nbsp; as well
+    :type strip_nbsp: bool
+    :return: The stripped text
+    :rtype: str
+    """
+
+    stripped_text = (
+        re.compile(pattern=r"&nbsp;").sub(repl="", string=strip_tags(value=text))
+        if strip_nbsp
+        else strip_tags(value=text)
+    )
+
+    logger.debug(msg=f"Stripped text: {stripped_text}")
+
+    return stripped_text
 
 
 def prepare_message_for_discord(
@@ -120,7 +146,7 @@ def prepare_message_for_discord(
     """
     Prepare a message for Discord
 
-    We have to run strip_tags() twice here.
+    We have to run strip_html_tags() twice here.
     1.  To remove HTML tags from the text, we want to send
     2.  After html.unescape() in case that unescaped former escaped HTML tags,
         which now need to be removed as well
@@ -133,14 +159,16 @@ def prepare_message_for_discord(
     :rtype:
     """
 
-    return strip_tags(
-        value=html.unescape(
-            s=strip_tags(
-                value=(
+    return strip_html_tags(
+        text=html.unescape(
+            s=strip_html_tags(
+                text=(
                     message[:message_length] + "…"
                     if len(message) > message_length
                     else message
-                )
+                ),
+                strip_nbsp=True,
             )
-        )
+        ),
+        strip_nbsp=True,
     )

--- a/aa_forum/tests/test_integration.py
+++ b/aa_forum/tests/test_integration.py
@@ -230,6 +230,7 @@ class TestForumUI(WebTest):
         # given
         self.app.set_user(user=self.user_1001)
         page = self.app.get(url=self.board.get_absolute_url())
+        old_topic_count = self.board.topics.count()
 
         # when
         page = page.click(linkid="aa-forum-btn-new-topic-above-list")
@@ -238,8 +239,10 @@ class TestForumUI(WebTest):
         form["message"] = ""  # Omitting mandatory field
         response = form.submit()
 
+        new_topic_count = self.board.topics.count()
+
         # then
-        self.assertEqual(first=self.board.topics.count(), second=0)  # No topic created
+        self.assertEqual(first=old_topic_count, second=new_topic_count)
         self.assertTemplateUsed(
             response=response, template_name="aa_forum/view/forum/new-topic.html"
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "allianceauth>=4.3.1,<5",
     "allianceauth-app-utils>=1.24",
     "dhooks-lite>=1.1",
-    "django-ckeditor-5>=0.2.14",
+    "django-ckeditor-5>=0.2.15",
     "unidecode>=1.3.7",
 ]
 optional-dependencies.tests-allianceauth-latest = [


### PR DESCRIPTION
## Description

### Changed

- Enable form validation for CKEditor fields, where needed
- Dependency updates
  - `django-ckeditor-5`>=0.2.15

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
