### PR TITLE
[CHANGE] Use `text-bg-*` instead of `bg-*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Section Order:
 
 ### Changed
 
+- Use `text-bg-*` instead of `bg-*` to make use of Bootstraps native color contrast detection
 - Backend App renamed (AA Forum > Forum)
 - JavaScript refactored
 

--- a/aa_forum/locale/django.pot
+++ b/aa_forum/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: AA Forum 2.10.2\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-forum/issues\n"
-"POT-Creation-Date: 2025-04-09 11:04+0200\n"
+"POT-Creation-Date: 2025-05-05 22:03+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -40,7 +40,7 @@ msgstr ""
 
 #: aa_forum/apps.py:20
 #, python-brace-format
-msgid "AA Forum v{__version__}"
+msgid "Forum v{__version__}"
 msgstr ""
 
 #: aa_forum/forms.py:43

--- a/aa_forum/templates/aa_forum/partials/administration/board-loop.html
+++ b/aa_forum/templates/aa_forum/partials/administration/board-loop.html
@@ -31,7 +31,7 @@
     </div>
 
     <div class="collapse" id="collapseEditBoard-{{ board.board_obj.pk }}" style="margin-top: 1rem;">
-        <div class="card card-body bg-light mb-3 py-3">
+        <div class="card card-body text-bg-secondary mb-3 py-3">
             <p>
                 {% translate "Changing the name of this board does not change its URL part. This will remain the same to not break any possible links into this board." %}
             </p>
@@ -72,7 +72,7 @@
             </p>
 
             <div class="collapse" id="collapseNewChildBoardForm-{{ board.board_obj.pk }}">
-                <div class="card card-body bg-light mb-3 py-3">
+                <div class="card card-body text-bg-secondary mb-3 py-3">
                     <p>
                         {% translate "New boards will be added at the bottom of the board list for this category. You can move them via drag and drop to a position of your liking." %}
                     </p>

--- a/aa_forum/templates/aa_forum/partials/administration/category-loop.html
+++ b/aa_forum/templates/aa_forum/partials/administration/category-loop.html
@@ -48,7 +48,7 @@
 
         <div class="card-body px-3 py-0">
             <div class="collapse mt-3" id="collapseEditCategory-{{ category.category_obj.pk }}">
-                <div class="card card-body bg-light mb-3 py-3">
+                <div class="card card-body text-bg-secondary mb-3 py-3">
                     <p>
                         {% translate "Changing the name of this category does not change its URL part. This will remain the same to not break any possible links into this category." %}
                     </p>
@@ -79,7 +79,7 @@
                 </p>
 
                 <div class="collapse" id="collapseNewBoardForm-{{ category.category_obj.pk }}">
-                    <div class="card card-body bg-light mb-3 py-3">
+                    <div class="card card-body text-bg-secondary mb-3 py-3">
                         <p>
                             {% translate "New boards will be added at the bottom of the board list for this category. You can move them via drag and drop to a position of your liking." %}
                         </p>

--- a/aa_forum/templatetags/aa_forum.py
+++ b/aa_forum/templatetags/aa_forum.py
@@ -317,7 +317,7 @@ def personal_message_unread_count(user: User) -> str:
 
     if message_count > 0:
         return_value = mark_safe(
-            s=f'<span class="badge bg-light aa-forum-badge-personal-messages-unread-count">{message_count}</span>'  # pylint: disable=line-too-long
+            s=f'<span class="badge text-bg-secondary aa-forum-badge-personal-messages-unread-count">{message_count}</span>'  # pylint: disable=line-too-long
         )
 
     return return_value

--- a/aa_forum/tests/test_templatetags.py
+++ b/aa_forum/tests/test_templatetags.py
@@ -769,7 +769,7 @@ class TestForumTemplateVariables(TestCase):
         self.assertEqual(
             first=response,
             second=(
-                '<span class="badge bg-light aa-forum-badge-personal-messages-unread-count">1</span>'  # pylint: disable=line-too-long
+                '<span class="badge text-bg-secondary aa-forum-badge-personal-messages-unread-count">1</span>'  # pylint: disable=line-too-long
             ),
         )
 


### PR DESCRIPTION
## Description

### Changed

- Use `text-bg-*` instead of `bg-*` to make use of Bootstraps native color contrast detection

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
