### PR TITLE
[RELEASE] v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Section Order:
 ### Security
 -->
 
+## [2.12.0] - 2025-06-03
+
+### Changed
+
+- Translations updated
+
 ### Removed
 
 - Cache breaker for static files. Doesn't work as expected with `django-sri`.

--- a/aa_forum/__init__.py
+++ b/aa_forum/__init__.py
@@ -5,5 +5,5 @@ AA-Forum
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.11.0"
+__version__ = "2.12.0"
 __title__ = _("Forum")

--- a/aa_forum/locale/django.pot
+++ b/aa_forum/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Forum 2.11.0\n"
+"Project-Id-Version: AA Forum 2.12.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-forum/issues\n"
-"POT-Creation-Date: 2025-05-22 07:03+0200\n"
+"POT-Creation-Date: 2025-06-03 11:45+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [2.12.0] - 2025-06-03

### Changed

- Translations updated

### Removed

- Cache breaker for static files. Doesn't work as expected with `django-sri`.