### PR TITLE
[RELEASE] v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [3.0.0] - 2026-06-07
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5!**
@@ -1793,11 +1795,12 @@ python manage.py migrate aa_forum
 [2.9.0]: https://github.com/ppfeufer/aa-forum/compare/v2.8.1...v2.9.0 "v2.9.0"
 [2.9.1]: https://github.com/ppfeufer/aa-forum/compare/v2.9.0...v2.9.1 "v2.9.1"
 [2.9.2]: https://github.com/ppfeufer/aa-forum/compare/v2.9.1...v2.9.2 "v2.9.2"
+[3.0.0]: https://github.com/ppfeufer/aa-forum/compare/v2.15.0...v3.0.0 "v3.0.0"
 [aa time zones]: https://github.com/ppfeufer/aa-timezones "AA Time Zones"
 [aa-discordbot]: https://github.com/pvyParts/allianceauth-discordbot "AA-Discordbot"
 [admin board options]: https://raw.githubusercontent.com/ppfeufer/aa-forum/master/docs/images/admin-board-options.jpg "Admin Board Options"
 [discordproxy]: https://gitlab.com/ErikKalkoken/discordproxy "discordproxy"
-[in development]: https://github.com/ppfeufer/aa-forum/compare/v2.15.0...HEAD "In Development"
+[in development]: https://github.com/ppfeufer/aa-forum/compare/v3.0.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [new feature: announcement boards]: https://raw.githubusercontent.com/ppfeufer/aa-forum/master/docs/images/feature-announcement-board.jpg "New Feature: Announcement Boards"
 [new feature: support for aa-timezones]: https://user-images.githubusercontent.com/2989985/195106607-8caf39c1-7343-404b-a926-e3253558b1ce.png "New Feature: Support for aa-timezones"

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth
 installation Then install the latest release directly from PyPi.
 
 ```shell
-pip install aa-forum==2.15.0
+pip install aa-forum==3.0.0
 ```
 
 ### Step 2: Configure Alliance Auth<a name="step-2-configure-alliance-auth"></a>

--- a/aa_forum/__init__.py
+++ b/aa_forum/__init__.py
@@ -5,6 +5,6 @@ AA-Forum
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.15.0"
+__version__ = "3.0.0"
 __title__ = "Forum"
 __title_translated__ = _("Forum")


### PR DESCRIPTION
## [3.0.0] - 2026-06-07

> [!IMPORTANT]
> 
> **This version needs Alliance Auth v5!**
> 
> Please make sure to update your Alliance Auth instance **before** you install this
> version, otherwise an update to Alliance Auth will be pulled in unsupervised.

### Removed

- Support for Alliance Auth v4