### PR TITLE
[RELASE] v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [3.1.0] - 2026-07-08
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5.2.0 or newer!**
@@ -1812,11 +1814,12 @@ python manage.py migrate aa_forum
 [2.9.1]: https://github.com/ppfeufer/aa-forum/compare/v2.9.0...v2.9.1 "v2.9.1"
 [2.9.2]: https://github.com/ppfeufer/aa-forum/compare/v2.9.1...v2.9.2 "v2.9.2"
 [3.0.0]: https://github.com/ppfeufer/aa-forum/compare/v2.15.0...v3.0.0 "v3.0.0"
+[3.1.0]: https://github.com/ppfeufer/aa-forum/compare/v3.0.0...v3.1.0 "v3.1.0"
 [aa time zones]: https://github.com/ppfeufer/aa-timezones "AA Time Zones"
 [aa-discordbot]: https://github.com/pvyParts/allianceauth-discordbot "AA-Discordbot"
 [admin board options]: https://raw.githubusercontent.com/ppfeufer/aa-forum/master/docs/images/admin-board-options.jpg "Admin Board Options"
 [discordproxy]: https://gitlab.com/ErikKalkoken/discordproxy "discordproxy"
-[in development]: https://github.com/ppfeufer/aa-forum/compare/v3.0.0...HEAD "In Development"
+[in development]: https://github.com/ppfeufer/aa-forum/compare/v3.1.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [new feature: announcement boards]: https://raw.githubusercontent.com/ppfeufer/aa-forum/master/docs/images/feature-announcement-board.jpg "New Feature: Announcement Boards"
 [new feature: support for aa-timezones]: https://user-images.githubusercontent.com/2989985/195106607-8caf39c1-7343-404b-a926-e3253558b1ce.png "New Feature: Support for aa-timezones"

--- a/README.md
+++ b/README.md
@@ -104,16 +104,6 @@ these kinds of changes. For your own sanity, and mine :-)
 
 ## Installation<a name="installation"></a>
 
-> [!NOTE]
->
-> **AA Forum >= 2.0.0 needs at least Alliance Auth v4!**
->
-> Please make sure to update your Alliance Auth instance _before_ you install this
-> module or update to the latest version, otherwise an update to Alliance Auth will
-> be pulled in unsupervised.
->
-> The last version of AA Forum that supports Alliance Auth v3 is `1.19.5`.
-
 **Important**: Please make sure you meet all preconditions before you proceed:
 
 - AA Forum is a plugin for Alliance Auth. If you don't have Alliance Auth running
@@ -129,7 +119,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth
 installation Then install the latest release directly from PyPi.
 
 ```shell
-pip install aa-forum==3.0.0
+pip install aa-forum==3.1.0
 ```
 
 ### Step 2: Configure Alliance Auth<a name="step-2-configure-alliance-auth"></a>

--- a/aa_forum/__init__.py
+++ b/aa_forum/__init__.py
@@ -5,6 +5,6 @@ AA-Forum
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 __title__ = "Forum"
 __title_translated__ = _("Forum")

--- a/aa_forum/locale/django.pot
+++ b/aa_forum/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Forum 2.15.0\n"
+"Project-Id-Version: AA Forum 3.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-forum/issues\n"
-"POT-Creation-Date: 2026-06-02 12:26+0200\n"
+"POT-Creation-Date: 2026-07-08 13:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,156 +38,156 @@ msgstr ""
 msgid "Forum"
 msgstr ""
 
-#: aa_forum/forms.py:43
+#: aa_forum/forms.py:46
 msgid "This field is mandatory"
 msgstr ""
 
-#: aa_forum/forms.py:127 aa_forum/forms.py:362 aa_forum/forms.py:568
-#: aa_forum/forms.py:630
+#: aa_forum/forms.py:130 aa_forum/forms.py:365 aa_forum/forms.py:571
+#: aa_forum/forms.py:633
 msgid "Message"
 msgstr ""
 
-#: aa_forum/forms.py:138 aa_forum/forms.py:140 aa_forum/forms.py:187
-#: aa_forum/forms.py:189 aa_forum/forms.py:570
+#: aa_forum/forms.py:141 aa_forum/forms.py:143 aa_forum/forms.py:190
+#: aa_forum/forms.py:192 aa_forum/forms.py:573
 #: aa_forum/templates/aa_forum/partials/personal-messages/inbox/messages.html:25
 #: aa_forum/templates/aa_forum/partials/personal-messages/sent-messages/messages.html:25
 msgid "Subject"
 msgstr ""
 
-#: aa_forum/forms.py:154 aa_forum/forms.py:169 aa_forum/forms.py:375
-#: aa_forum/forms.py:390 aa_forum/forms.py:585 aa_forum/forms.py:600
-#: aa_forum/forms.py:643 aa_forum/forms.py:658
+#: aa_forum/forms.py:157 aa_forum/forms.py:172 aa_forum/forms.py:378
+#: aa_forum/forms.py:393 aa_forum/forms.py:588 aa_forum/forms.py:603
+#: aa_forum/forms.py:646 aa_forum/forms.py:661
 msgid "You have forgotten the message!"
 msgstr ""
 
-#: aa_forum/forms.py:201 aa_forum/forms.py:212
+#: aa_forum/forms.py:204 aa_forum/forms.py:215
 msgid "Boards"
 msgstr ""
 
-#: aa_forum/forms.py:203
+#: aa_forum/forms.py:206
 msgid ""
 "Boards to be created with this category (One board per line). These boards "
 "will have no group restrictions, so you have to add them later where needed."
 msgstr ""
 
-#: aa_forum/forms.py:225 aa_forum/forms.py:242 aa_forum/forms.py:283
+#: aa_forum/forms.py:228 aa_forum/forms.py:245 aa_forum/forms.py:286
 msgid "Name"
 msgstr ""
 
-#: aa_forum/forms.py:226 aa_forum/forms.py:243
+#: aa_forum/forms.py:229 aa_forum/forms.py:246
 msgid "Category name"
 msgstr ""
 
-#: aa_forum/forms.py:284
+#: aa_forum/forms.py:287
 msgid "Description"
 msgstr ""
 
-#: aa_forum/forms.py:285
+#: aa_forum/forms.py:288
 msgid "Group restrictions"
 msgstr ""
 
-#: aa_forum/forms.py:286
+#: aa_forum/forms.py:289
 msgid "Discord webhook (optional)"
 msgstr ""
 
-#: aa_forum/forms.py:288
+#: aa_forum/forms.py:291
 msgid "Use this Discord webhook for replies as well?"
 msgstr ""
 
-#: aa_forum/forms.py:290
+#: aa_forum/forms.py:293
 msgid "Mark board as \"Announcement Board\""
 msgstr ""
 
-#: aa_forum/forms.py:292
+#: aa_forum/forms.py:295
 msgid "Start topic restrictions for \"Announcement Boards\""
 msgstr ""
 
-#: aa_forum/forms.py:296
+#: aa_forum/forms.py:299
 msgid "Board name"
 msgstr ""
 
-#: aa_forum/forms.py:302 aa_forum/models.py:228
+#: aa_forum/forms.py:305 aa_forum/models.py:229
 msgid "Board description (optional)"
 msgstr ""
 
-#: aa_forum/forms.py:325
+#: aa_forum/forms.py:328
 msgid "Close topic"
 msgstr ""
 
-#: aa_forum/forms.py:327
+#: aa_forum/forms.py:330
 msgid "If checked, this topic will be closed after posting this message."
 msgstr ""
 
-#: aa_forum/forms.py:333
+#: aa_forum/forms.py:336
 msgid "Reopen topic"
 msgstr ""
 
-#: aa_forum/forms.py:335
+#: aa_forum/forms.py:338
 msgid "If checked, this topic will be reopened after posting this message."
 msgstr ""
 
-#: aa_forum/forms.py:415
+#: aa_forum/forms.py:418
 msgid "Your signature will appear below your posts."
 msgstr ""
 
-#: aa_forum/forms.py:416
+#: aa_forum/forms.py:419
 msgid "Your website's title."
 msgstr ""
 
-#: aa_forum/forms.py:418
+#: aa_forum/forms.py:421
 msgid ""
 "Your website's URL. (Don't forget to also set a title for your website, "
 "otherwise this field will be ignored.)"
 msgstr ""
 
-#: aa_forum/forms.py:423
+#: aa_forum/forms.py:426
 msgid ""
 "Information: There is currently no module installed that can handle Discord "
 "direct messages. Have a chat with your IT guys to remedy this."
 msgstr ""
 
-#: aa_forum/forms.py:432
+#: aa_forum/forms.py:435
 msgid ""
 "Activating this setting will ad a widget to your dashboard that shows unread "
 "topics in the forum."
 msgstr ""
 
-#: aa_forum/forms.py:438
+#: aa_forum/forms.py:441
 msgid "Signature"
 msgstr ""
 
-#: aa_forum/forms.py:439
+#: aa_forum/forms.py:442
 msgid "Website title"
 msgstr ""
 
-#: aa_forum/forms.py:440
+#: aa_forum/forms.py:443
 msgid "Website URL"
 msgstr ""
 
-#: aa_forum/forms.py:442
+#: aa_forum/forms.py:445
 msgid "PM me on Discord when I get a new personal message"
 msgstr ""
 
-#: aa_forum/forms.py:445
+#: aa_forum/forms.py:448
 msgid "Show unread topics as widget on the dashboard"
 msgstr ""
 
-#: aa_forum/forms.py:451
+#: aa_forum/forms.py:454
 msgid "e.g.: My Homepage"
 msgstr ""
 
-#: aa_forum/forms.py:485
+#: aa_forum/forms.py:488
 #, python-brace-format
 msgid ""
 "Ensure your signature has at most {max_signature_length} characters. "
 "(Currently: {current_signature_length})"
 msgstr ""
 
-#: aa_forum/forms.py:510
+#: aa_forum/forms.py:513
 msgid "This is not a valid URL"
 msgstr ""
 
-#: aa_forum/forms.py:569
+#: aa_forum/forms.py:572
 #: aa_forum/templates/aa_forum/partials/personal-messages/sent-messages/messages.html:21
 msgid "Recipient"
 msgstr ""
@@ -196,47 +196,47 @@ msgstr ""
 msgid "Error:"
 msgstr ""
 
-#: aa_forum/models.py:125
+#: aa_forum/models.py:126
 msgid "AA-Forum"
 msgstr ""
 
-#: aa_forum/models.py:129
+#: aa_forum/models.py:130
 msgid "Can access the AA-Forum module"
 msgstr ""
 
-#: aa_forum/models.py:132
+#: aa_forum/models.py:133
 msgid "Can manage the AA-Forum module (Category, topics and messages)"
 msgstr ""
 
-#: aa_forum/models.py:179
+#: aa_forum/models.py:180
 msgid "category"
 msgstr ""
 
-#: aa_forum/models.py:180
+#: aa_forum/models.py:181
 msgid "categories"
 msgstr ""
 
-#: aa_forum/models.py:236
+#: aa_forum/models.py:237
 msgid ""
 "Discord webhook URL for the channel to post about new topics in this board. "
 "(This setting is optional)"
 msgstr ""
 
-#: aa_forum/models.py:243
+#: aa_forum/models.py:244
 msgid ""
 "Use this Discord webhook for replies as well? When activated every reply to "
 "any topic in this board will be posted to the defined Discord channel. "
 "(Child boards are excluded) Chose wisely! (Default: NO)"
 msgstr ""
 
-#: aa_forum/models.py:261
+#: aa_forum/models.py:262
 msgid ""
 "This will restrict access to this board to the selected groups. If no groups "
 "are selected, everyone who can access the forum can also access this board. "
 "(This setting is optional)"
 msgstr ""
 
-#: aa_forum/models.py:269
+#: aa_forum/models.py:270
 msgid ""
 "Mark this board as an \"Announcement Board\", meaning that only certain "
 "selected groups can start new topics. All others who have access to this "
@@ -244,7 +244,7 @@ msgid ""
 "not be inherited to child boards. (Default: NO)"
 msgstr ""
 
-#: aa_forum/models.py:280
+#: aa_forum/models.py:281
 msgid ""
 "User in at least one of the selected groups will be able to start topics in "
 "\"Announcement Boards\". If no group is selected, only forum admins can do "
@@ -253,98 +253,98 @@ msgid ""
 "Board\", see checkbox above.)"
 msgstr ""
 
-#: aa_forum/models.py:318
+#: aa_forum/models.py:319
 msgid "board"
 msgstr ""
 
-#: aa_forum/models.py:319
+#: aa_forum/models.py:320
 msgid "boards"
 msgstr ""
 
-#: aa_forum/models.py:391
+#: aa_forum/models.py:392
 #, python-brace-format
 msgid ""
 "<h4>Warning!</h4><p>There is already a topic with the exact same subject in "
 "this board.</p><p>See here: <a href=\"{topic_url}\">{topic_subject}</a></p>"
 msgstr ""
 
-#: aa_forum/models.py:622
+#: aa_forum/models.py:623
 msgid "topic"
 msgstr ""
 
-#: aa_forum/models.py:623
+#: aa_forum/models.py:624
 msgid "topics"
 msgstr ""
 
-#: aa_forum/models.py:802
+#: aa_forum/models.py:803
 msgid "message"
 msgstr ""
 
-#: aa_forum/models.py:803
+#: aa_forum/models.py:804
 msgid "messages"
 msgstr ""
 
-#: aa_forum/models.py:945
+#: aa_forum/models.py:946
 msgid "personal message"
 msgstr ""
 
-#: aa_forum/models.py:946
+#: aa_forum/models.py:947
 msgid "personal messages"
 msgstr ""
 
-#: aa_forum/models.py:1000
+#: aa_forum/models.py:1001
 msgid "Messages per page"
 msgstr ""
 
-#: aa_forum/models.py:1001
+#: aa_forum/models.py:1002
 msgid "Topics per page"
 msgstr ""
 
-#: aa_forum/models.py:1002
+#: aa_forum/models.py:1003
 msgid "User signature length"
 msgstr ""
 
-#: aa_forum/models.py:1008
+#: aa_forum/models.py:1009
 msgid ""
 "How many messages per page should be displayed in a forum topic? (Default: "
 "15)"
 msgstr ""
 
-#: aa_forum/models.py:1016
+#: aa_forum/models.py:1017
 msgid ""
 "How many topics per page should be displayed in a forum category? (Default: "
 "10)"
 msgstr ""
 
-#: aa_forum/models.py:1024
+#: aa_forum/models.py:1025
 msgid ""
 "How long (Number of characters) is a user's signature allowed to be? "
 "(Default: 750)"
 msgstr ""
 
-#: aa_forum/models.py:1037
+#: aa_forum/models.py:1038
 msgid "setting"
 msgstr ""
 
-#: aa_forum/models.py:1038
+#: aa_forum/models.py:1039
 msgid "settings"
 msgstr ""
 
-#: aa_forum/models.py:1048
+#: aa_forum/models.py:1049
 #: aa_forum/templates/aa_forum/partials/administration/settings-form.html:7
 #: aa_forum/templates/aa_forum/partials/menu/menu-admin.html:19
 msgid "Forum settings"
 msgstr ""
 
-#: aa_forum/models.py:1075
+#: aa_forum/models.py:1076
 msgid "user profile"
 msgstr ""
 
-#: aa_forum/models.py:1076
+#: aa_forum/models.py:1077
 msgid "user profiles"
 msgstr ""
 
-#: aa_forum/models.py:1086
+#: aa_forum/models.py:1087
 msgid "Forum user profile"
 msgstr ""
 


### PR DESCRIPTION
## [3.1.0] - 2026-07-08

> [!IMPORTANT]
>
> **This version needs Alliance Auth v5.2.0 or newer!**
>
> Please make sure to update your Alliance Auth instance **before** you install this
> version, otherwise an update to Alliance Auth will be pulled in unsupervised.

### Added

- Support for Python 3.14

### Changed

- Migrated to Alliance Auth proxy models for `Permission`, `User` and `Group`
- Translations updated