### PR TITLE
[CHANGE] Use `pk` instead of `id` when referring to the primary key

### DIFF
--- a/.github/workflows/automated-checks.yml
+++ b/.github/workflows/automated-checks.yml
@@ -3,7 +3,7 @@ name: Tests
 env:
   COVERAGE_DATABASE_VERSION: mariadb:10.11
   COVERAGE_PYTHON_VERSION: 3.12
-  NODE_VERSION: 24 # [LTS] End of Life: 30 Apr 2028 (https://endoflife.date/nodejs)
+  NODE_VERSION: 26 # [LTS] End of Life: 30 Apr 2029 (https://endoflife.date/nodejs)
   REDIS_VERSION: latest
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,4 +58,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # The name of the file(s) to upload
           files: |
-            dist/*
+            dist/*.tar.gz
+            dist/*.whl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 # Set the default language versions for the hooks
 default_language_version:
   python: python3  # Force all Python hooks to use Python 3
-  node: 24.14.0  # Force all Node hooks to use this specific Node version
+  node: 26.3.0  # Force all Node hooks to use this specific Node version
 
 # https://pre-commit.ci/
 ci:
@@ -68,7 +68,7 @@ repos:
         name: Check for large files
         description: Check for large files that were added to the repository.
         args:
-          - --maxkb=1000
+          - --maxkb=2048  # 2 MB
 
       - id: detect-private-key
         name: Detect private key
@@ -120,8 +120,10 @@ repos:
         name: End of file fixer
         description: Ensure that files end with a newline.
 
-  - repo: https://github.com/eslint/eslint
-    rev: 9089853a593d6c7c0f11367da08a829e0ddfe092  # frozen: v10.6.0
+#  - repo: https://github.com/eslint/eslint
+#    rev: 9089853a593d6c7c0f11367da08a829e0ddfe092  # frozen: v10.6.0
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: 8763fc929b6232999d541a3d8eb49965a6b71afb  # frozen: v10.6.0
     hooks:
       - id: eslint
         name: ESLint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Section Order:
 
 <!-- Your changes go here -->
 
+### Changed
+
+- Use `pk` instead of `id` when referring to the primary key of a model instance, since `id` is not guaranteed to be the primary key in Django.
+
 ## [3.1.0] - 2026-07-08
 
 > [!IMPORTANT]

--- a/aa_forum/scripts/fake_messages.py
+++ b/aa_forum/scripts/fake_messages.py
@@ -88,7 +88,7 @@ def run():
                         # Can not bulk create, or we would not get first and last
                         # messages
                         Message.objects.create(
-                            topic_id=topic.id,
+                            topic_id=topic.pk,
                             message=f"<p>{fake.sentence()}</p>",
                             user_created_id=random.choice(user_ids),
                         )

--- a/aa_forum/templates/aa_forum/partials/breadcrumb.html
+++ b/aa_forum/templates/aa_forum/partials/breadcrumb.html
@@ -10,7 +10,7 @@
         {% endif %}
 
         {% if category %}
-            <li>» <a href="{% url 'aa_forum:forum_index' %}#category-{{ category.id }}">{{ category.name }}</a></li>
+            <li>» <a href="{% url 'aa_forum:forum_index' %}#category-{{ category.pk }}">{{ category.name }}</a></li>
 
             {% if board %}
                 {% aa_forum_template_variable category_slug = category.slug %}

--- a/aa_forum/templates/aa_forum/partials/forum/board/board-index.html
+++ b/aa_forum/templates/aa_forum/partials/forum/board/board-index.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<div id="category-{{ category.id }}" class="card card-default card-aa-forum-category mb-3">
+<div id="category-{{ category.pk }}" class="card card-default card-aa-forum-category mb-3">
     <div class="card-header">
         <div class="card-title mb-0">{{ board.name }}</div>
     </div>

--- a/aa_forum/templates/aa_forum/partials/forum/board/board.html
+++ b/aa_forum/templates/aa_forum/partials/forum/board/board.html
@@ -11,7 +11,7 @@
 <div class="aa-forum-board d-md-flex px-0 py-3">
     <div class="aa-forum-board-image me-3">
         {% if board.num_unread > 0 %}
-            <svg id="aa-forum-unread-in-{{ board.id }}" class="svg-icon-post-new">
+            <svg id="aa-forum-unread-in-{{ board.pk }}" class="svg-icon-post-new">
                 <use href="#aa-forum-icon-post"></use>
             </svg>
         {% else %}

--- a/aa_forum/templates/aa_forum/partials/forum/board/topic.html
+++ b/aa_forum/templates/aa_forum/partials/forum/board/topic.html
@@ -6,7 +6,7 @@
     <div class="aa-forum-topic p-3">
         <div class="aa-forum-topic-image">
             {% if topic.has_unread_messages %}
-                <svg id="aa-forum-unread-in-{{ board.id }}" class="svg-icon-post-new">
+                <svg id="aa-forum-unread-in-{{ board.pk }}" class="svg-icon-post-new">
                     <use href="#aa-forum-icon-post"></use>
                 </svg>
             {% else %}
@@ -22,7 +22,7 @@
 
                 {% if topic.has_unread_messages %}
                     <a
-                        id="aa-forum-link-new-{{ topic.id }}"
+                        id="aa-forum-link-new-{{ topic.pk }}"
                         href="{% url 'aa_forum:forum_topic_first_unread_message' topic.board.category.slug topic.board.slug topic.slug %}"
                         class="badge text-bg-warning label-aa-forum-topic-new-message ms-2"
                         title="{% translate 'Go to first unread message' %}"

--- a/aa_forum/templates/aa_forum/partials/forum/forum-index.html
+++ b/aa_forum/templates/aa_forum/partials/forum/forum-index.html
@@ -1,5 +1,5 @@
 {% for category in categories %}
-    <div id="category-{{ category.id }}" class="card card-default card-aa-forum-category mb-3">
+    <div id="category-{{ category.pk }}" class="card card-default card-aa-forum-category mb-3">
         <div class="card-header">
             <div class="card-title mb-0">{{ category.name }}</div>
         </div>

--- a/aa_forum/templates/aa_forum/partials/forum/topic/message.html
+++ b/aa_forum/templates/aa_forum/partials/forum/topic/message.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load aa_forum %}
 
-<div id="message-{{ message.id }}" class="card card-default mb-3">
+<div id="message-{{ message.pk }}" class="card card-default mb-3">
     {% aa_forum_template_variable message_author = message.user_created %}
 
     <div class="card-body">

--- a/aa_forum/templates/aa_forum/partials/forum/topic/unread-topics.html
+++ b/aa_forum/templates/aa_forum/partials/forum/topic/unread-topics.html
@@ -1,4 +1,4 @@
-<div id="category-{{ board.category.id }}" class="card card-default card-aa-forum-category mb-3">
+<div id="category-{{ board.category.pk }}" class="card card-default card-aa-forum-category mb-3">
     <div class="card-header">
         <div class="card-title mb-0">
             {{ board.category.name }} »

--- a/aa_forum/tests/test_integration.py
+++ b/aa_forum/tests/test_integration.py
@@ -1333,8 +1333,8 @@ class TestAdminCategoriesAndBoardsUI(WebTest):
         )
 
         # when
-        form = page.forms[f"aa-forum-form-admin-add-board-{category.id}"]
-        form[f"new-board-in-category-{category.id}-name"] = "Board"
+        form = page.forms[f"aa-forum-form-admin-add-board-{category.pk}"]
+        form[f"new-board-in-category-{category.pk}-name"] = "Board"
 
         # Ensure CSRF cookie is present for webtest (Django requires a CSRF cookie
         # in addition to the hidden csrfmiddlewaretoken input). Extract the token

--- a/aa_forum/tests/test_views_forum.py
+++ b/aa_forum/tests/test_views_forum.py
@@ -116,9 +116,9 @@ class TestIndexViews(BaseTestCase):
 
         # then
         self.assertEqual(first=res.status_code, second=HTTPStatus.OK)
-        self.assertContains(response=res, text=f"aa-forum-unread-in-{self.board_1.id}")
+        self.assertContains(response=res, text=f"aa-forum-unread-in-{self.board_1.pk}")
         self.assertNotContains(
-            response=res, text=f"aa-forum-unread-in-{self.board_2.id}"
+            response=res, text=f"aa-forum-unread-in-{self.board_2.pk}"
         )
 
     def test_should_show_new_indicator_when_new_posts_are_made(self):
@@ -142,7 +142,7 @@ class TestIndexViews(BaseTestCase):
 
         # then
         self.assertEqual(first=res.status_code, second=HTTPStatus.OK)
-        self.assertContains(response=res, text=f"aa-forum-unread-in-{self.board_2.id}")
+        self.assertContains(response=res, text=f"aa-forum-unread-in-{self.board_2.pk}")
 
     def test_should_show_counts(self):
         """
@@ -316,7 +316,7 @@ class TestBoardViews(BaseTestCase):
 
         # then
         self.assertEqual(first=res.status_code, second=HTTPStatus.OK)
-        self.assertContains(response=res, text=f"aa-forum-link-new-{self.topic_1.id}")
+        self.assertContains(response=res, text=f"aa-forum-link-new-{self.topic_1.pk}")
 
     def test_should_show_new_indicator_when_seen_first_page_only(self):
         """
@@ -345,7 +345,7 @@ class TestBoardViews(BaseTestCase):
 
         # then
         self.assertEqual(first=res.status_code, second=HTTPStatus.OK)
-        self.assertContains(response=res, text=f"aa-forum-link-new-{self.topic_1.id}")
+        self.assertContains(response=res, text=f"aa-forum-link-new-{self.topic_1.pk}")
 
     def test_should_show_new_indicator_when_seen_second_page_only(self):
         """
@@ -374,7 +374,7 @@ class TestBoardViews(BaseTestCase):
 
         # then
         self.assertEqual(first=res.status_code, second=HTTPStatus.OK)
-        self.assertContains(response=res, text=f"aa-forum-link-new-{self.topic_1.id}")
+        self.assertContains(response=res, text=f"aa-forum-link-new-{self.topic_1.pk}")
 
     def test_should_not_show_new_indicator_when_seen_last_page(self):
         """
@@ -404,7 +404,7 @@ class TestBoardViews(BaseTestCase):
         # then
         self.assertEqual(first=res.status_code, second=HTTPStatus.OK)
         self.assertNotContains(
-            response=res, text=f"aa-forum-link-new-{self.topic_1.id}"
+            response=res, text=f"aa-forum-link-new-{self.topic_1.pk}"
         )
 
     def test_should_show_new_indicator_when_new_posts_are_made(self):
@@ -431,7 +431,7 @@ class TestBoardViews(BaseTestCase):
 
         # then
         self.assertEqual(first=res.status_code, second=HTTPStatus.OK)
-        self.assertContains(response=res, text=f"aa-forum-link-new-{self.topic_2.id}")
+        self.assertContains(response=res, text=f"aa-forum-link-new-{self.topic_2.pk}")
 
     def test_should_delete_topic(self):
         """

--- a/aa_forum/views/admin.py
+++ b/aa_forum/views/admin.py
@@ -69,7 +69,7 @@ def categories_and_boards(request: WSGIRequest) -> HttpResponse:
                     "board_obj": child_board,
                     "board_forms": {
                         "board_edit_form": EditBoardForm(
-                            prefix="edit-board-" + str(child_board.id),
+                            prefix="edit-board-" + str(child_board.pk),
                             instance=child_board,
                             groups_queryset=groups_queryset,
                         ),
@@ -83,10 +83,10 @@ def categories_and_boards(request: WSGIRequest) -> HttpResponse:
                     "board_obj": board,
                     "board_forms": {
                         "new_child_board_form": EditBoardForm(
-                            prefix="new-child-board-" + str(board.id)
+                            prefix="new-child-board-" + str(board.pk)
                         ),
                         "board_edit_form": EditBoardForm(
-                            prefix="edit-board-" + str(board.id),
+                            prefix="edit-board-" + str(board.pk),
                             instance=board,
                             groups_queryset=groups_queryset,
                         ),
@@ -99,11 +99,11 @@ def categories_and_boards(request: WSGIRequest) -> HttpResponse:
             "category_obj": category,
             "category_forms": {
                 "new_board": EditBoardForm(
-                    prefix="new-board-in-category-" + str(category.id),
+                    prefix="new-board-in-category-" + str(category.pk),
                     groups_queryset=groups_queryset,
                 ),
                 "edit_category": EditCategoryForm(
-                    prefix="edit-category-" + str(category.id), instance=category
+                    prefix="edit-category-" + str(category.pk), instance=category
                 ),
             },
             "boards": boards_data,

--- a/aa_forum/views/forum.py
+++ b/aa_forum/views/forum.py
@@ -106,7 +106,7 @@ def index(request: WSGIRequest) -> HttpResponse:
 
         if category.pk not in categories_map:
             categories_map[category.pk] = {
-                "id": category.id,
+                "id": category.pk,
                 "name": category.name,
                 "boards_sorted": [],
                 "order": category.order,
@@ -905,7 +905,7 @@ def topic_reply(
                 category_slug=category_slug,
                 board_slug=board_slug,
                 topic_slug=topic_slug,
-                message_id=new_message.id,
+                message_id=new_message.pk,
             )
 
         messages.error(
@@ -1186,7 +1186,7 @@ def message_modify(
 
     # Check if the user actually has the right to edit this message
     if (
-        message_to_modify.user_created_id != request.user.id
+        message_to_modify.user_created_id != request.user.pk
         and not request.user.has_perm(perm="aa_forum.manage_forum")
     ):
         messages.error(
@@ -1334,7 +1334,7 @@ def message_delete(request: WSGIRequest, message_id: int) -> HttpResponseRedirec
 
     # Safety check to make sure the user is allowed to delete this message
     if (
-        current_message.user_created_id != request.user.id
+        current_message.user_created_id != request.user.pk
         and not request.user.has_perm(perm="aa_forum.manage_forum")
     ):
         messages.error(

--- a/aa_forum/views/personal_messages.py
+++ b/aa_forum/views/personal_messages.py
@@ -405,7 +405,7 @@ def ajax_read_message(request: WSGIRequest, folder: str) -> HttpResponse:
         return HttpResponse(status=HTTPStatus.NO_CONTENT)
 
     # Validate user permissions and get message
-    user_id = request.user.id
+    user_id = request.user.pk
 
     if not (
         (folder == "inbox" and user_id == recipient_id)


### PR DESCRIPTION
## Description

### Changed

- Use `pk` instead of `id` when referring to the primary key of a model instance, since `id` is not guaranteed to be the primary key in Django.

## Type of Change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
